### PR TITLE
Implement deletion of annotations

### DIFF
--- a/app/SessionProviderWrapper.tsx
+++ b/app/SessionProviderWrapper.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import React from 'react';
+import { SessionProvider } from 'next-auth/react';
+
+interface SessionProviderWrapperProps {
+  children: React.ReactNode;
+}
+
+export function SessionProviderWrapper({
+  children,
+}: SessionProviderWrapperProps) {
+  return <SessionProvider>{children}</SessionProvider>;
+}

--- a/app/api/annotations/[id]/route.ts
+++ b/app/api/annotations/[id]/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+import { deleteAnnotation } from '@/lib/annoRepo';
+
+export async function DELETE(
+  request: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params;
+
+  const annotationUrl = `https://annorepo.globalise.huygens.knaw.nl/w3c/necessary-reunions/${encodeURIComponent(
+    id,
+  )}`;
+
+  try {
+    await deleteAnnotation(annotationUrl);
+    return new NextResponse(null, { status: 204 });
+  } catch (err: any) {
+    console.error('Error deleting annotation:', err);
+    return new NextResponse(JSON.stringify({ error: err.message }), {
+      status: 500,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+}

--- a/app/api/annotations/[id]/route.ts
+++ b/app/api/annotations/[id]/route.ts
@@ -1,10 +1,20 @@
 import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../../auth/[...nextauth]/authOptions';
 import { deleteAnnotation } from '@/lib/annoRepo';
 
 export async function DELETE(
   request: Request,
   context: { params: Promise<{ id: string }> },
 ) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json(
+      { error: 'Unauthorized – please sign in to delete annotations' },
+      { status: 401 },
+    );
+  }
+
   const { id } = await context.params;
 
   const annotationUrl = `https://annorepo.globalise.huygens.knaw.nl/w3c/necessary-reunions/${encodeURIComponent(
@@ -16,9 +26,9 @@ export async function DELETE(
     return new NextResponse(null, { status: 204 });
   } catch (err: any) {
     console.error('Error deleting annotation:', err);
-    return new NextResponse(JSON.stringify({ error: err.message }), {
-      status: 500,
-      headers: { 'content-type': 'application/json' },
-    });
+    return NextResponse.json(
+      { error: err.message || 'Unknown error' },
+      { status: 500 },
+    );
   }
 }

--- a/app/api/annotations/route.ts
+++ b/app/api/annotations/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(request: Request) {
+  // TODO: implement createAnnotation in lib/annoRepo.ts and import here
+  try {
+    const body = await request.json();
+    // const created = await createAnnotation(body);
+    // return NextResponse.json(created, { status: 201 });
+    return new NextResponse('Not implemented', { status: 501 });
+  } catch (err: any) {
+    console.error('Error creating annotation:', err);
+    return new NextResponse(JSON.stringify({ error: err.message }), {
+      status: 500,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+}

--- a/app/api/auth/[...nextauth]/authOptions.js
+++ b/app/api/auth/[...nextauth]/authOptions.js
@@ -31,16 +31,20 @@ export const authOptions = {
   ],
 
   callbacks: {
+    async signIn({ user }) {
+      const allowlist = (process.env.ORCID_ALLOWLIST || '').split(',');
+      if (allowlist.includes(user.id)) return true;
+      return false;
+    },
+
     async jwt({ token, user, account }) {
       if (account?.access_token) {
         token.accessToken = account.access_token;
       }
-
       if (user) {
         token.sub = user.id;
         token.label = user.label;
       }
-
       return token;
     },
 
@@ -54,9 +58,10 @@ export const authOptions = {
       return session;
     },
   },
+
   pages: {
     signIn: '/',
-    error: '/',
+    error: '/unauthorized',
   },
 
   secret: process.env.NEXTAUTH_SECRET,

--- a/app/api/auth/[...nextauth]/authOptions.ts
+++ b/app/api/auth/[...nextauth]/authOptions.ts
@@ -1,4 +1,9 @@
-export const authOptions = {
+// app/api/auth/[...nextauth]/authOptions.ts
+
+import type { NextAuthOptions } from 'next-auth';
+import type { JWT } from 'next-auth/jwt';
+
+export const authOptions: NextAuthOptions = {
   providers: [
     {
       id: 'orcid',
@@ -6,8 +11,8 @@ export const authOptions = {
       type: 'oauth',
       version: '2.0',
       wellKnown: 'https://orcid.org/.well-known/openid-configuration',
-      clientId: process.env.ORCID_CLIENT_ID,
-      clientSecret: process.env.ORCID_CLIENT_SECRET,
+      clientId: process.env.ORCID_CLIENT_ID!,
+      clientSecret: process.env.ORCID_CLIENT_SECRET!,
       authorization: {
         url: 'https://orcid.org/oauth/authorize',
         params: {
@@ -32,30 +37,32 @@ export const authOptions = {
 
   callbacks: {
     async signIn({ user }) {
-      const allowlist = (process.env.ORCID_ALLOWLIST || '').split(',');
-      if (allowlist.includes(user.id)) return true;
-      return false;
+      const allowlist = (process.env.ORCID_ALLOWLIST ?? '').split(',');
+      return allowlist.includes(user.id);
     },
 
     async jwt({ token, user, account }) {
       if (account?.access_token) {
-        token.accessToken = account.access_token;
+        (token as any).accessToken = account.access_token;
       }
       if (user) {
         token.sub = user.id;
-        token.label = user.label;
+        (token as any).label = (user as any).label;
       }
       return token;
     },
 
     async session({ session, token }) {
-      session.user = {
-        id: token.sub,
-        type: 'Person',
-        label: token.label,
-      };
-      session.accessToken = token.accessToken;
-      return session;
+      return {
+        ...session,
+        user: {
+          ...(session.user as object),
+          id: token.sub as string,
+          type: 'Person',
+          label: (token as any).label as string,
+        },
+        accessToken: (token as any).accessToken as string,
+      } as any;
     },
   },
 
@@ -64,5 +71,5 @@ export const authOptions = {
     error: '/unauthorized',
   },
 
-  secret: process.env.NEXTAUTH_SECRET,
+  secret: process.env.NEXTAUTH_SECRET!,
 };

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,6 +1,5 @@
-import NextAuth from 'next-auth';
+import NextAuth from 'next-auth/next';
 import { authOptions } from './authOptions';
 
 const handler = NextAuth(authOptions);
-
 export { handler as GET, handler as POST };

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import { Toaster } from '@/components/Toaster';
 import { Header } from '@/components/Header';
 import { Footer } from '@/components/Footer';
 import { Providers } from './providers';
+import { SessionProviderWrapper } from './SessionProviderWrapper';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -56,14 +57,16 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${lexend.variable} ${roboto.variable}font-body bg-white text-foreground antialiased grid grid-rows-[auto_1fr_auto] h-full overflow-hidden`}
+        className={`${lexend.variable} ${roboto.variable} font-body bg-white text-foreground antialiased grid grid-rows-[auto_1fr_auto] h-full overflow-hidden`}
       >
-        <Providers>
-          <Header />
-        </Providers>
-        <main className="flex-1 overflow-hidden">{children}</main>
-        <Footer />
-        <Toaster />
+        <SessionProviderWrapper>
+          <Providers>
+            <Header />
+            <main className="flex-1 overflow-hidden">{children}</main>
+            <Footer />
+            <Toaster />
+          </Providers>
+        </SessionProviderWrapper>
       </body>
     </html>
   );

--- a/app/unauthorized/page.tsx
+++ b/app/unauthorized/page.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { signIn } from 'next-auth/react';
+import { Button } from '@/components/Button';
+import { LogIn } from 'lucide-react';
+
+export default function UnauthorizedPage() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gray-50">
+      <h1 className="text-3xl font-semibold mb-4">Access Denied</h1>
+      <p className="mb-6 text-center max-w-md">
+        The ORCID iD provided is not authorised to access this application.
+        Please contact the administrator if access should be granted.
+      </p>
+      <Button
+        onClick={() => signIn('orcid', { callbackUrl: window.location.origin })}
+        variant="secondary"
+      >
+        <LogIn className="h-4 w-4 mr-1" />
+        Try Signing In Again
+      </Button>
+    </div>
+  );
+}

--- a/components/AllmapsMap.tsx
+++ b/components/AllmapsMap.tsx
@@ -115,7 +115,7 @@ export default function AllmapsMap({
   };
 
   return (
-    <div className="relative w-full h-full">
+    <div className="relative w-full h-full pb-14 sm:pb-0">
       {initialized &&
         mapRef.current &&
         warpedRef.current &&

--- a/components/AnnotationList.tsx
+++ b/components/AnnotationList.tsx
@@ -213,15 +213,15 @@ export function AnnotationList({
                     </div>
 
                     {isExpanded && (
-                      <div className="mt-3 bg-gray-50 p-3 rounded text-sm space-y-2 break-words">
-                        <div className="text-xs text-gray-400">
+                      <div className="mt-3 bg-gray-50 p-3 rounded text-sm space-y-2 break-words whitespace-pre-wrap w-full">
+                        <div className="text-xs text-gray-400 whitespace-pre-wrap">
                           <strong>ID:</strong> {annotation.id.split('/').pop()}
                         </div>
-                        <div>
+                        <div className="whitespace-pre-wrap break-all">
                           <strong>Target source:</strong>{' '}
                           {annotation.target.source}
                         </div>
-                        <div>
+                        <div className="whitespace-pre-wrap">
                           <strong>Selector type:</strong>{' '}
                           {annotation.target.selector.type}
                         </div>

--- a/components/AnnotationList.tsx
+++ b/components/AnnotationList.tsx
@@ -103,7 +103,6 @@ export function AnnotationList({
       </div>
 
       <div className="overflow-auto flex-1" ref={listRef}>
-        {/* Show a subtle loading overlay instead of replacing the list */}
         {isLoading && filtered.length > 0 && (
           <div className="absolute inset-0 bg-white bg-opacity-40 flex items-center justify-center pointer-events-none z-10">
             <LoadingSpinner />

--- a/components/AnnotationList.tsx
+++ b/components/AnnotationList.tsx
@@ -10,6 +10,7 @@ interface AnnotationListProps {
   annotations: Annotation[];
   onAnnotationSelect: (id: string) => void;
   onAnnotationPrepareDelete?: (anno: Annotation) => void;
+  canEdit: boolean;
   showTextspotting: boolean;
   showIconography: boolean;
   onFilterChange: (mot: 'textspotting' | 'iconography') => void;
@@ -25,6 +26,7 @@ export function AnnotationList({
   annotations,
   onAnnotationSelect,
   onAnnotationPrepareDelete,
+  canEdit,
   showTextspotting,
   showIconography,
   onFilterChange,
@@ -225,14 +227,15 @@ export function AnnotationList({
                   <button
                     onClick={(e) => {
                       e.stopPropagation();
-                      console.log(
-                        '[List delete] preparing delete for:',
-                        annotation.id,
-                      );
                       onAnnotationPrepareDelete?.(annotation);
                     }}
+                    disabled={!canEdit}
                     aria-label="Delete annotation"
-                    className="ml-4 p-1 text-red-600 hover:text-red-800"
+                    className={`ml-4 p-1 ${
+                      canEdit
+                        ? 'text-red-600 hover:text-red-800'
+                        : 'text-gray-400 cursor-not-allowed'
+                    }`}
                   >
                     <Trash2 className="h-5 w-5" />
                   </button>

--- a/components/AnnotationList.tsx
+++ b/components/AnnotationList.tsx
@@ -103,7 +103,13 @@ export function AnnotationList({
       </div>
 
       <div className="overflow-auto flex-1" ref={listRef}>
-        {isLoading ? (
+        {/* Show a subtle loading overlay instead of replacing the list */}
+        {isLoading && filtered.length > 0 && (
+          <div className="absolute inset-0 bg-white bg-opacity-40 flex items-center justify-center pointer-events-none z-10">
+            <LoadingSpinner />
+          </div>
+        )}
+        {isLoading && filtered.length === 0 ? (
           <div className="flex flex-col justify-center items-center py-8">
             <LoadingSpinner />
             <p className="mt-4 text-sm text-gray-500">Loading annotations…</p>
@@ -124,7 +130,7 @@ export function AnnotationList({
             No annotations for this image
           </div>
         ) : (
-          <div className="divide-y">
+          <div className="divide-y relative">
             {filtered.map((annotation) => {
               let bodies = getBodies(annotation);
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -5,8 +5,8 @@ import OrcidAuth from './OrcidAuth';
 export function Header() {
   return (
     <header className="bg-primary text-primary-foreground border-b border-border">
-      <div className="w-full px-4 flex items-center justify-between py-2">
-        <div className="flex items-center space-x-2">
+      <div className="w-full px-2 sm:px-4 flex flex-col sm:flex-row items-center justify-between py-2 gap-2 sm:gap-0">
+        <div className="flex items-center space-x-2 w-full sm:w-auto justify-center sm:justify-start">
           <Link href="/" aria-label="Home">
             <Image
               src="/image/recharted-logo.png"
@@ -16,14 +16,14 @@ export function Header() {
               height={32}
             />
           </Link>
-          <h1 className="text-2xl font-heading text-white">re:Charted</h1>
+          <h1 className="text-xl sm:text-2xl font-heading text-white">re:Charted</h1>
         </div>
-        <nav aria-label="Main">
+        <nav aria-label="Main" className="w-full sm:w-auto flex justify-center sm:justify-end">
           <ul className="flex space-x-4 items-center">
             <li>
               <OrcidAuth />
             </li>
-            <li>
+            <li className="hidden sm:block">
               <Link href="/about" className="font-medium text-white">
                 About
               </Link>

--- a/components/ImageViewer.tsx
+++ b/components/ImageViewer.tsx
@@ -46,12 +46,10 @@ export function ImageViewer({
     selectedIdRef.current = selectedAnnotationId;
   }, [selectedAnnotationId]);
 
-  // Save viewport before annotation list changes (e.g., deletion)
   useEffect(() => {
     if (viewerRef.current && viewerRef.current.viewport) {
       lastViewportRef.current = viewerRef.current.viewport.getBounds();
     }
-    // Only run before annotations change
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [annotations.length]);
 
@@ -184,7 +182,6 @@ export function ImageViewer({
         viewerRef.current = viewer;
         onViewerReady?.(viewer);
 
-        // Restore previous viewport if available
         viewer.addHandler('open', () => {
           setLoading(false);
           if (lastViewportRef.current) {

--- a/components/ImageViewer.tsx
+++ b/components/ImageViewer.tsx
@@ -14,7 +14,6 @@ interface ImageViewerProps {
   onViewerReady?: (viewer: any) => void;
   showTextspotting: boolean;
   showIconography: boolean;
-  onAnnotationPrepareDelete?: (anno: Annotation) => void;
 }
 
 export function ImageViewer({
@@ -26,7 +25,6 @@ export function ImageViewer({
   onViewerReady,
   showTextspotting,
   showIconography,
-  onAnnotationPrepareDelete,
 }: ImageViewerProps) {
   const mountRef = useRef<HTMLDivElement>(null);
   const viewerRef = useRef<any>(null);
@@ -272,9 +270,7 @@ export function ImageViewer({
             div.addEventListener('pointerdown', (e) => e.stopPropagation());
             div.addEventListener('click', (e) => {
               e.stopPropagation();
-              console.log('[Overlay click] preparing delete for:', anno.id);
               onSelectRef.current?.(anno.id);
-              onAnnotationPrepareDelete?.(anno);
             });
             div.addEventListener('mouseenter', (e) => {
               const tt = tooltipRef.current!;

--- a/components/ImageViewer.tsx
+++ b/components/ImageViewer.tsx
@@ -14,6 +14,7 @@ interface ImageViewerProps {
   onViewerReady?: (viewer: any) => void;
   showTextspotting: boolean;
   showIconography: boolean;
+  onAnnotationPrepareDelete?: (anno: Annotation) => void;
 }
 
 export function ImageViewer({
@@ -25,6 +26,7 @@ export function ImageViewer({
   onViewerReady,
   showTextspotting,
   showIconography,
+  onAnnotationPrepareDelete,
 }: ImageViewerProps) {
   const mountRef = useRef<HTMLDivElement>(null);
   const viewerRef = useRef<any>(null);
@@ -38,6 +40,7 @@ export function ImageViewer({
   useEffect(() => {
     onSelectRef.current = onAnnotationSelect;
   }, [onAnnotationSelect]);
+
   useEffect(() => {
     selectedIdRef.current = selectedAnnotationId;
   }, [selectedAnnotationId]);
@@ -215,7 +218,7 @@ export function ImageViewer({
             }
             if (!svgVal) continue;
 
-            const match = svgVal.match(/<polygon points="([^"]+)"/);
+            const match = svgVal.match(/<polygon points="([^\"]+)"/);
             if (!match) continue;
 
             const coords = match[1]
@@ -269,7 +272,9 @@ export function ImageViewer({
             div.addEventListener('pointerdown', (e) => e.stopPropagation());
             div.addEventListener('click', (e) => {
               e.stopPropagation();
+              console.log('[Overlay click] preparing delete for:', anno.id);
               onSelectRef.current?.(anno.id);
+              onAnnotationPrepareDelete?.(anno);
             });
             div.addEventListener('mouseenter', (e) => {
               const tt = tooltipRef.current!;

--- a/components/ImageViewer.tsx
+++ b/components/ImageViewer.tsx
@@ -35,7 +35,6 @@ export function ImageViewer({
   const onSelectRef = useRef(onAnnotationSelect);
   const selectedIdRef = useRef<string | null>(selectedAnnotationId);
 
-  // Store the last viewport bounds before annotation changes
   const lastViewportRef = useRef<any>(null);
 
   useEffect(() => {
@@ -104,7 +103,13 @@ export function ImageViewer({
     setLoading(true);
     setNoSource(false);
     setErrorMsg(null);
-    viewerRef.current?.destroy();
+
+    if (viewerRef.current) {
+      try {
+        viewerRef.current.destroy();
+      } catch (e) {}
+      viewerRef.current = null;
+    }
     overlaysRef.current = [];
     vpRectsRef.current = {};
 
@@ -334,7 +339,17 @@ export function ImageViewer({
     }
 
     initViewer();
-    return () => viewerRef.current?.destroy();
+
+    return () => {
+      if (viewerRef.current) {
+        try {
+          viewerRef.current.destroy();
+        } catch (e) {}
+        viewerRef.current = null;
+      }
+      overlaysRef.current = [];
+      vpRectsRef.current = {};
+    };
   }, [manifest, currentCanvas, annotations, showTextspotting, showIconography]);
 
   useEffect(() => {
@@ -357,7 +372,6 @@ export function ImageViewer({
     <div className={cn('w-full h-full relative')}>
       <div ref={mountRef} className="w-full h-full" />
 
-      {/* Subtle loading overlay if loading and annotations are present */}
       {loading && annotations.length > 0 && (
         <div className="absolute inset-0 bg-white bg-opacity-40 z-20 flex items-center justify-center pointer-events-none">
           <LoadingSpinner />

--- a/components/ManifestViewer.tsx
+++ b/components/ManifestViewer.tsx
@@ -14,6 +14,7 @@ import type { Manifest } from '@/lib/types';
 import { ImageViewer } from '@/components/ImageViewer';
 import { useAllAnnotations } from '@/hooks/use-all-annotations';
 import { AnnotationList } from '@/components/AnnotationList';
+import type { Annotation } from '@/lib/types';
 
 const AllmapsMap = dynamic(() => import('./AllmapsMap'), { ssr: false });
 const MetadataSidebar = dynamic(
@@ -23,6 +24,9 @@ const MetadataSidebar = dynamic(
 
 export function ManifestViewer() {
   const [manifest, setManifest] = useState<Manifest | null>(null);
+  const [deleteCandidate, setDeleteCandidate] = useState<Annotation | null>(
+    null,
+  );
   const [isLoadingManifest, setIsLoadingManifest] = useState(true);
   const [manifestError, setManifestError] = useState<string | null>(null);
   const { toast } = useToast();
@@ -161,6 +165,11 @@ export function ManifestViewer() {
               currentCanvas={currentCanvasIndex}
             />
           )}
+          {deleteCandidate && (
+            <div className="p-4 bg-yellow-100 border-t">
+              <strong>Delete candidate:</strong> {deleteCandidate.id}
+            </div>
+          )}
         </div>
 
         {isRightSidebarVisible && (
@@ -206,6 +215,7 @@ export function ManifestViewer() {
                   showTextspotting={showTextspotting}
                   showIconography={showIconography}
                   onFilterChange={onFilterChange}
+                  onAnnotationPrepareDelete={setDeleteCandidate}
                 />
               )}
               {viewMode === 'map' && (

--- a/components/ManifestViewer.tsx
+++ b/components/ManifestViewer.tsx
@@ -42,15 +42,11 @@ export function ManifestViewer() {
   const [showTextspotting, setShowTextspotting] = useState(true);
   const [showIconography, setShowIconography] = useState(true);
 
-  // Optimistic annotation state
   const [localAnnotations, setLocalAnnotations] = useState<Annotation[]>([]);
   const canvasId = manifest?.items?.[currentCanvasIndex]?.id ?? '';
-  const {
-    annotations,
-    isLoading: isLoadingAnnotations,
-  } = useAllAnnotations(canvasId);
+  const { annotations, isLoading: isLoadingAnnotations } =
+    useAllAnnotations(canvasId);
 
-  // Sync localAnnotations with loaded annotations
   useEffect(() => {
     setLocalAnnotations(annotations);
   }, [annotations]);
@@ -125,7 +121,6 @@ export function ManifestViewer() {
 
   const handleDelete = async (annotation: Annotation) => {
     const annoName = annotation.id.split('/').pop()!;
-    // Optimistically remove annotation
     setLocalAnnotations((prev) => prev.filter((a) => a.id !== annotation.id));
     try {
       const res = await fetch(

--- a/components/ManifestViewer.tsx
+++ b/components/ManifestViewer.tsx
@@ -37,6 +37,14 @@ export function ManifestViewer() {
     string | null
   >(null);
 
+  const [showTextspotting, setShowTextspotting] = useState(true);
+  const [showIconography, setShowIconography] = useState(true);
+
+  const onFilterChange = (mot: 'textspotting' | 'iconography') => {
+    if (mot === 'textspotting') setShowTextspotting((v) => !v);
+    else setShowIconography((v) => !v);
+  };
+
   const canvasId = manifest?.items?.[currentCanvasIndex]?.id ?? '';
   const { annotations, isLoading: isLoadingAnnotations } =
     useAllAnnotations(canvasId);
@@ -143,6 +151,8 @@ export function ManifestViewer() {
                 selectedAnnotationId={selectedAnnotationId}
                 onAnnotationSelect={setSelectedAnnotationId}
                 onViewerReady={() => {}}
+                showTextspotting={showTextspotting}
+                showIconography={showIconography}
               />
             )}
           {viewMode === 'map' && (
@@ -193,6 +203,9 @@ export function ManifestViewer() {
                   isLoading={isLoadingAnnotations}
                   selectedAnnotationId={selectedAnnotationId}
                   onAnnotationSelect={setSelectedAnnotationId}
+                  showTextspotting={showTextspotting}
+                  showIconography={showIconography}
+                  onFilterChange={onFilterChange}
                 />
               )}
               {viewMode === 'map' && (

--- a/components/ManifestViewer.tsx
+++ b/components/ManifestViewer.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { Button } from '@/components/Button';
-import { Loader2, Info, MessageSquare, Map } from 'lucide-react';
+import { Loader2, Info, MessageSquare, Map, Images } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { CollectionSidebar } from '@/components/CollectionSidebar';
 import { TopNavigation } from '@/components/Navbar';
@@ -14,6 +14,14 @@ import { useAllAnnotations } from '@/hooks/use-all-annotations';
 import { AnnotationList } from '@/components/AnnotationList';
 import type { Annotation } from '@/lib/types';
 import { useSession } from 'next-auth/react';
+import { useIsMobile } from '@/hooks/use-mobile';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/Sheet';
+import { PanelLeft } from 'lucide-react';
 
 const AllmapsMap = dynamic(() => import('./AllmapsMap'), { ssr: false });
 const MetadataSidebar = dynamic(
@@ -46,6 +54,13 @@ export function ManifestViewer() {
   const canvasId = manifest?.items?.[currentCanvasIndex]?.id ?? '';
   const { annotations, isLoading: isLoadingAnnotations } =
     useAllAnnotations(canvasId);
+
+  const isMobile = useIsMobile();
+  const [mobileView, setMobileView] = useState<
+    'image' | 'annotation' | 'map' | 'gallery' | 'info'
+  >('image');
+  const [isGalleryOpen, setIsGalleryOpen] = useState(false);
+  const [isInfoOpen, setIsInfoOpen] = useState(false);
 
   useEffect(() => {
     setLocalAnnotations(annotations);
@@ -134,9 +149,7 @@ export function ManifestViewer() {
         throw new Error(data.error ?? `${res.status}`);
       }
       toast({ title: 'Annotation deleted' });
-      // Optionally, you could trigger a manual refresh here if needed
     } catch (err: any) {
-      // Restore annotation if delete failed
       setLocalAnnotations((prev) => [...prev, annotation]);
       toast({ title: 'Delete failed', description: err.message });
     }
@@ -150,106 +163,220 @@ export function ManifestViewer() {
         onToggleRightSidebar={() => setIsRightSidebarVisible((p) => !p)}
       />
 
-      <div className="flex-1 flex overflow-hidden">
-        {isLeftSidebarVisible && (
-          <div className="w-64 border-r flex flex-col overflow-hidden">
-            <CollectionSidebar
-              manifest={manifest}
-              currentCanvas={currentCanvasIndex}
-              onCanvasSelect={setCurrentCanvasIndex}
-            />
-          </div>
-        )}
-
-        <div className="flex-1 relative overflow-hidden">
-          {(viewMode === 'image' || viewMode === 'annotation') &&
-            currentCanvas && (
-              <ImageViewer
-                manifest={manifest}
-                currentCanvas={currentCanvasIndex}
-                annotations={viewMode === 'annotation' ? localAnnotations : []}
-                selectedAnnotationId={selectedAnnotationId}
-                onAnnotationSelect={setSelectedAnnotationId}
-                onViewerReady={() => {}}
-                showTextspotting={showTextspotting}
-                showIconography={showIconography}
-              />
-            )}
-          {viewMode === 'map' && (
-            <AllmapsMap
-              manifest={manifest}
-              currentCanvas={currentCanvasIndex}
-            />
-          )}
-        </div>
-
-        {isRightSidebarVisible && (
-          <div className="w-80 border-l flex flex-col overflow-hidden">
-            <div className="flex border-b">
-              <Button
-                variant={viewMode === 'image' ? 'default' : 'ghost'}
-                className="flex-1 h-10"
-                onClick={() => setViewMode('image')}
-              >
-                <Info className="h-4 w-4 mr-1" /> Info
-              </Button>
-              <Button
-                variant={viewMode === 'annotation' ? 'default' : 'ghost'}
-                className="flex-1 h-10"
-                onClick={() => setViewMode('annotation')}
-              >
-                <MessageSquare className="h-4 w-4 mr-1" /> Annotations
-              </Button>
-              <Button
-                variant={viewMode === 'map' ? 'default' : 'ghost'}
-                className="flex-1 h-10"
-                onClick={() => setViewMode('map')}
-              >
-                <Map className="h-4 w-4 mr-1" /> Map
-              </Button>
-            </div>
-            <div className="flex-1 overflow-auto">
-              {viewMode === 'image' && (
-                <MetadataSidebar
+      {/* Desktop layout */}
+      {!isMobile && (
+        <>
+          <div className="flex-1 flex overflow-hidden">
+            {isLeftSidebarVisible && (
+              <div className="w-64 border-r flex flex-col overflow-hidden">
+                <CollectionSidebar
                   manifest={manifest}
                   currentCanvas={currentCanvasIndex}
-                  activeTab="metadata"
-                  onChange={setManifest}
+                  onCanvasSelect={setCurrentCanvasIndex}
+                />
+              </div>
+            )}
+
+            <div className="flex-1 relative overflow-hidden">
+              {(viewMode === 'image' || viewMode === 'annotation') &&
+                currentCanvas && (
+                  <ImageViewer
+                    manifest={manifest}
+                    currentCanvas={currentCanvasIndex}
+                    annotations={
+                      viewMode === 'annotation' ? localAnnotations : []
+                    }
+                    selectedAnnotationId={selectedAnnotationId}
+                    onAnnotationSelect={setSelectedAnnotationId}
+                    onViewerReady={() => {}}
+                    showTextspotting={showTextspotting}
+                    showIconography={showIconography}
+                  />
+                )}
+              {viewMode === 'map' && (
+                <AllmapsMap
+                  manifest={manifest}
+                  currentCanvas={currentCanvasIndex}
                 />
               )}
-              {viewMode === 'annotation' && (
-                <AnnotationList
-                  annotations={localAnnotations}
-                  isLoading={isLoadingAnnotations}
+            </div>
+
+            {isRightSidebarVisible && (
+              <div className="w-80 border-l flex flex-col overflow-hidden">
+                <div className="flex border-b">
+                  <Button
+                    variant={viewMode === 'image' ? 'default' : 'ghost'}
+                    className="flex-1 h-10"
+                    onClick={() => setViewMode('image')}
+                  >
+                    <Info className="h-4 w-4 mr-1" /> Info
+                  </Button>
+                  <Button
+                    variant={viewMode === 'annotation' ? 'default' : 'ghost'}
+                    className="flex-1 h-10"
+                    onClick={() => setViewMode('annotation')}
+                  >
+                    <MessageSquare className="h-4 w-4 mr-1" /> Annotations
+                  </Button>
+                  <Button
+                    variant={viewMode === 'map' ? 'default' : 'ghost'}
+                    className="flex-1 h-10"
+                    onClick={() => setViewMode('map')}
+                  >
+                    <Map className="h-4 w-4 mr-1" /> Map
+                  </Button>
+                </div>
+                <div className="flex-1 overflow-auto">
+                  {viewMode === 'image' && (
+                    <MetadataSidebar
+                      manifest={manifest}
+                      currentCanvas={currentCanvasIndex}
+                      activeTab="metadata"
+                      onChange={setManifest}
+                    />
+                  )}
+                  {viewMode === 'annotation' && (
+                    <AnnotationList
+                      annotations={localAnnotations}
+                      isLoading={isLoadingAnnotations}
+                      selectedAnnotationId={selectedAnnotationId}
+                      onAnnotationSelect={setSelectedAnnotationId}
+                      showTextspotting={showTextspotting}
+                      showIconography={showIconography}
+                      onFilterChange={onFilterChange}
+                      onAnnotationPrepareDelete={
+                        canEdit ? handleDelete : undefined
+                      }
+                      canEdit={canEdit}
+                    />
+                  )}
+                  {viewMode === 'map' && (
+                    <MetadataSidebar
+                      manifest={manifest}
+                      currentCanvas={currentCanvasIndex}
+                      activeTab="geo"
+                      onChange={setManifest}
+                    />
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+          <StatusBar
+            manifest={manifest}
+            currentCanvas={currentCanvasIndex}
+            totalCanvases={manifest.items.length}
+            onCanvasChange={setCurrentCanvasIndex}
+            viewMode={viewMode === 'annotation' ? undefined : viewMode}
+          />
+        </>
+      )}
+
+      {/* Mobile layout */}
+      {isMobile && (
+        <>
+          <div className="flex-1 relative overflow-hidden">
+            {(mobileView === 'image' || mobileView === 'annotation') &&
+              currentCanvas && (
+                <ImageViewer
+                  manifest={manifest}
+                  currentCanvas={currentCanvasIndex}
+                  annotations={
+                    mobileView === 'annotation' ? localAnnotations : []
+                  }
                   selectedAnnotationId={selectedAnnotationId}
                   onAnnotationSelect={setSelectedAnnotationId}
+                  onViewerReady={() => {}}
                   showTextspotting={showTextspotting}
                   showIconography={showIconography}
-                  onFilterChange={onFilterChange}
-                  onAnnotationPrepareDelete={canEdit ? handleDelete : undefined}
-                  canEdit={canEdit}
                 />
               )}
-              {viewMode === 'map' && (
-                <MetadataSidebar
-                  manifest={manifest}
-                  currentCanvas={currentCanvasIndex}
-                  activeTab="geo"
-                  onChange={setManifest}
-                />
-              )}
-            </div>
+            {mobileView === 'map' && (
+              <AllmapsMap
+                manifest={manifest}
+                currentCanvas={currentCanvasIndex}
+              />
+            )}
           </div>
-        )}
-      </div>
 
-      <StatusBar
-        manifest={manifest}
-        currentCanvas={currentCanvasIndex}
-        totalCanvases={manifest.items.length}
-        onCanvasChange={setCurrentCanvasIndex}
-        viewMode={viewMode === 'annotation' ? undefined : viewMode}
-      />
+          {/* Gallery Sheet */}
+          <Sheet open={isGalleryOpen} onOpenChange={setIsGalleryOpen}>
+            <SheetContent side="bottom" className="max-h-[80vh] p-0">
+              <SheetHeader>
+                <SheetTitle>Gallery</SheetTitle>
+              </SheetHeader>
+              <CollectionSidebar
+                manifest={manifest}
+                currentCanvas={currentCanvasIndex}
+                onCanvasSelect={(idx) => {
+                  setCurrentCanvasIndex(idx);
+                  setIsGalleryOpen(false);
+                }}
+              />
+            </SheetContent>
+          </Sheet>
+
+          {/* Info Sheet */}
+          <Sheet open={isInfoOpen} onOpenChange={setIsInfoOpen}>
+            <SheetContent side="bottom" className="max-h-[80vh] p-0">
+              <SheetHeader>
+                <SheetTitle>Info</SheetTitle>
+              </SheetHeader>
+              <MetadataSidebar
+                manifest={manifest}
+                currentCanvas={currentCanvasIndex}
+                activeTab={mobileView === 'map' ? 'geo' : 'metadata'}
+                onChange={setManifest}
+              />
+            </SheetContent>
+          </Sheet>
+
+          {/* Mobile Bottom NavBar */}
+          <nav className="fixed bottom-0 left-0 right-0 z-50 bg-white border-t flex justify-around h-14">
+            <button
+              className="flex flex-col items-center justify-center flex-1 text-xs"
+              onClick={() => setIsGalleryOpen(true)}
+            >
+              <Images className="h-6 w-6 mb-0.5" />
+              Gallery
+            </button>
+            <button
+              className={`flex flex-col items-center justify-center flex-1 text-xs ${
+                mobileView === 'image' ? 'text-primary' : ''
+              }`}
+              onClick={() => setMobileView('image')}
+            >
+              <PanelLeft className="h-6 w-6 mb-0.5" />
+              Image
+            </button>
+            <button
+              className={`flex flex-col items-center justify-center flex-1 text-xs ${
+                mobileView === 'annotation' ? 'text-primary' : ''
+              }`}
+              onClick={() => setMobileView('annotation')}
+            >
+              <MessageSquare className="h-6 w-6 mb-0.5" />
+              Anno
+            </button>
+            <button
+              className={`flex flex-col items-center justify-center flex-1 text-xs ${
+                mobileView === 'map' ? 'text-primary' : ''
+              }`}
+              onClick={() => setMobileView('map')}
+            >
+              <Map className="h-6 w-6 mb-0.5" />
+              Map
+            </button>
+            <button
+              className="flex flex-col items-center justify-center flex-1 text-xs"
+              onClick={() => setIsInfoOpen(true)}
+            >
+              <Info className="h-6 w-6 mb-0.5" />
+              Info
+            </button>
+          </nav>
+        </>
+      )}
     </div>
   );
 }

--- a/components/ManifestViewer.tsx
+++ b/components/ManifestViewer.tsx
@@ -13,6 +13,7 @@ import { ImageViewer } from '@/components/ImageViewer';
 import { useAllAnnotations } from '@/hooks/use-all-annotations';
 import { AnnotationList } from '@/components/AnnotationList';
 import type { Annotation } from '@/lib/types';
+import { useSession } from 'next-auth/react';
 
 const AllmapsMap = dynamic(() => import('./AllmapsMap'), { ssr: false });
 const MetadataSidebar = dynamic(
@@ -25,6 +26,8 @@ export function ManifestViewer() {
   const [isLoadingManifest, setIsLoadingManifest] = useState(true);
   const [manifestError, setManifestError] = useState<string | null>(null);
   const { toast } = useToast();
+  const { status } = useSession();
+  const canEdit = status === 'authenticated';
 
   const [currentCanvasIndex, setCurrentCanvasIndex] = useState(0);
   const [isLeftSidebarVisible, setIsLeftSidebarVisible] = useState(true);
@@ -114,7 +117,6 @@ export function ManifestViewer() {
 
   const currentCanvas = manifest.items[currentCanvasIndex];
 
-  // Handler for deletion triggered by trash icon
   const handleDelete = async (annotation: Annotation) => {
     const annoName = annotation.id.split('/').pop()!;
     try {
@@ -219,7 +221,8 @@ export function ManifestViewer() {
                   showTextspotting={showTextspotting}
                   showIconography={showIconography}
                   onFilterChange={onFilterChange}
-                  onAnnotationPrepareDelete={handleDelete}
+                  onAnnotationPrepareDelete={canEdit ? handleDelete : undefined}
+                  canEdit={canEdit}
                 />
               )}
               {viewMode === 'map' && (

--- a/components/MetadataSidebar.tsx
+++ b/components/MetadataSidebar.tsx
@@ -32,6 +32,16 @@ export function MetadataSidebar({
   const canvas = manifest.items?.[currentCanvas];
   const [allmapsAnno, setAllmapsAnno] = useState<any>(null);
   const [detailed, setDetailed] = useState<any>(null);
+  const [showTextspotting, setShowTextspotting] = useState(true);
+  const [showIconography, setShowIconography] = useState(true);
+
+  const handleFilterChange = (mot: 'textspotting' | 'iconography') => {
+    if (mot === 'textspotting') {
+      setShowTextspotting((v) => !v);
+    } else {
+      setShowIconography((v) => !v);
+    }
+  };
 
   const renderField = (label: string, content: React.ReactNode) => (
     <div>
@@ -70,6 +80,9 @@ export function MetadataSidebar({
           annotations={annotations}
           isLoading={isLoading}
           onAnnotationSelect={(id) => console.log('Selected annotation:', id)}
+          showTextspotting={showTextspotting}
+          showIconography={showIconography}
+          onFilterChange={handleFilterChange}
         />
       </div>
     );

--- a/components/MetadataSidebar.tsx
+++ b/components/MetadataSidebar.tsx
@@ -80,6 +80,7 @@ export function MetadataSidebar({
           annotations={annotations}
           isLoading={isLoading}
           onAnnotationSelect={(id) => console.log('Selected annotation:', id)}
+          canEdit={false}
           showTextspotting={showTextspotting}
           showIconography={showIconography}
           onFilterChange={handleFilterChange}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -19,16 +19,28 @@ export function TopNavigation({
   const title = getLocalizedValue(manifest.label) || 'Untitled Manifest';
 
   return (
-    <div className="border-b flex items-center justify-between px-4 py-2">
-      <div className="flex items-center gap-4">
-        <Button variant="outline" size="icon" onClick={onToggleLeftSidebar}>
+    <div className="border-b flex items-center justify-between px-2 sm:px-4 py-2">
+      <div className="flex items-center gap-2 sm:gap-4">
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={onToggleLeftSidebar}
+          className="h-8 w-8 sm:h-10 sm:w-10"
+        >
           <PanelLeft className="h-5 w-5" />
         </Button>
-        <span className="font-medium truncate max-w-md">{title}</span>
+        <span className="font-medium truncate max-w-[120px] sm:max-w-md text-base sm:text-lg">
+          {title}
+        </span>
       </div>
 
       <div className="flex items-center gap-2">
-        <Button variant="outline" size="icon" onClick={onToggleRightSidebar}>
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={onToggleRightSidebar}
+          className="h-8 w-8 sm:h-10 sm:w-10 hidden sm:inline-flex"
+        >
           <PanelRight className="h-5 w-5" />
         </Button>
       </div>

--- a/components/OrcidAuth.tsx
+++ b/components/OrcidAuth.tsx
@@ -27,27 +27,33 @@ export default function OrcidAuth() {
   }
 
   return (
-    <div className="flex items-center space-x-1 sm:space-x-3">
+    <div className="flex items-center space-x-3">
       {!session ? (
         <Button
           onClick={() =>
             signIn('orcid', { callbackUrl: window.location.origin })
           }
           variant="secondary"
-          aria-label="Sign in with ORCID"
-          className="p-2 h-8 w-8 flex items-center justify-center"
         >
-          <LogIn className="h-5 w-5" />
+          <LogIn className="h-4 w-4 mr-1" />
+          Sign in
         </Button>
       ) : (
-        <Button
-          onClick={() => signOut()}
-          variant="default"
-          aria-label="Sign out"
-          className="p-2 h-8 w-8 flex items-center justify-center"
-        >
-          <LogOut className="h-5 w-5" />
-        </Button>
+        <>
+          <span className="text-sm text-white">
+            {(session.user as SessionUser)?.label}
+            <br />
+            <small>ORCID: {(session.user as SessionUser)?.id}</small>
+          </span>
+          <Button
+            onClick={() => signOut()}
+            variant="default"
+            className="hover:text-secondary"
+          >
+            <LogOut className="h-4 w-4 mr-1" />
+            Sign out
+          </Button>
+        </>
       )}
     </div>
   );

--- a/components/OrcidAuth.tsx
+++ b/components/OrcidAuth.tsx
@@ -19,7 +19,6 @@ export default function OrcidAuth() {
   const { data: session, status } = useSession();
 
   if (status === 'loading') {
-    // centre the spinner however suits your layout
     return (
       <div className="flex items-center justify-center h-10">
         <LoadingSpinner />
@@ -28,33 +27,27 @@ export default function OrcidAuth() {
   }
 
   return (
-    <div className="flex items-center space-x-3">
+    <div className="flex items-center space-x-1 sm:space-x-3">
       {!session ? (
         <Button
           onClick={() =>
             signIn('orcid', { callbackUrl: window.location.origin })
           }
           variant="secondary"
+          aria-label="Sign in with ORCID"
+          className="p-2 h-8 w-8 flex items-center justify-center"
         >
-          <LogIn className="h-4 w-4 mr-1" />
-          Sign in
+          <LogIn className="h-5 w-5" />
         </Button>
       ) : (
-        <>
-          <span className="text-sm text-white">
-            {(session.user as SessionUser)?.label}
-            <br />
-            <small>ORCID: {(session.user as SessionUser)?.id}</small>
-          </span>
-          <Button
-            onClick={() => signOut()}
-            variant="default"
-            className="hover:text-secondary"
-          >
-            <LogOut className="h-4 w-4 mr-1" />
-            Sign out
-          </Button>
-        </>
+        <Button
+          onClick={() => signOut()}
+          variant="default"
+          aria-label="Sign out"
+          className="p-2 h-8 w-8 flex items-center justify-center"
+        >
+          <LogOut className="h-5 w-5" />
+        </Button>
       )}
     </div>
   );

--- a/components/OrcidAuth.tsx
+++ b/components/OrcidAuth.tsx
@@ -3,6 +3,7 @@
 import { signIn, signOut, useSession } from 'next-auth/react';
 import { LogIn, LogOut } from 'lucide-react';
 import { Button } from './Button';
+import { LoadingSpinner } from './LoadingSpinner';
 
 interface SessionUser {
   id: string;
@@ -15,18 +16,25 @@ interface SessionData {
 }
 
 export default function OrcidAuth() {
-  const { data: session } = useSession() as { data: SessionData | null };
+  const { data: session, status } = useSession();
+
+  if (status === 'loading') {
+    // centre the spinner however suits your layout
+    return (
+      <div className="flex items-center justify-center h-10">
+        <LoadingSpinner />
+      </div>
+    );
+  }
 
   return (
     <div className="flex items-center space-x-3">
       {!session ? (
         <Button
           onClick={() =>
-            signIn('orcid', {
-              callbackUrl: window.location.origin,
-            })
+            signIn('orcid', { callbackUrl: window.location.origin })
           }
-          variant={'secondary'}
+          variant="secondary"
         >
           <LogIn className="h-4 w-4 mr-1" />
           Sign in
@@ -34,13 +42,13 @@ export default function OrcidAuth() {
       ) : (
         <>
           <span className="text-sm text-white">
-            {session.user.label}
+            {(session.user as SessionUser)?.label}
             <br />
-            <small>ORCID: {session.user.id}</small>
+            <small>ORCID: {(session.user as SessionUser)?.id}</small>
           </span>
           <Button
             onClick={() => signOut()}
-            variant={'default'}
+            variant="default"
             className="hover:text-secondary"
           >
             <LogOut className="h-4 w-4 mr-1" />

--- a/lib/annoRepo.ts
+++ b/lib/annoRepo.ts
@@ -42,3 +42,51 @@ export async function fetchAnnotations({
 
   return { items, hasMore };
 }
+
+const AUTH_HEADER = {
+  Authorization: `Bearer ${process.env.ANNO_REPO_TOKEN_JONA}`,
+};
+
+export async function deleteAnnotation(annotationUrl: string): Promise<void> {
+  let etag: string | null = null;
+  const headRes = await fetch(annotationUrl, {
+    method: 'HEAD',
+    headers: {
+      ...AUTH_HEADER,
+      Accept: 'application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"',
+    },
+  });
+  if (headRes.ok) {
+    etag = headRes.headers.get('etag');
+  }
+
+  if (!etag) {
+    const getRes = await fetch(annotationUrl, {
+      method: 'GET',
+      headers: {
+        ...AUTH_HEADER,
+        Accept:
+          'application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"',
+      },
+    });
+    if (!getRes.ok) {
+      throw new Error(`Failed to fetch annotation for ETag: ${getRes.status}`);
+    }
+    etag = getRes.headers.get('etag');
+  }
+
+  if (!etag) {
+    throw new Error('No ETag header on annotation resource');
+  }
+
+  const delRes = await fetch(annotationUrl, {
+    method: 'DELETE',
+    headers: {
+      ...AUTH_HEADER,
+      'If-Match': etag,
+    },
+  });
+  if (!delRes.ok) {
+    throw new Error(`Delete failed: ${delRes.status} ${delRes.statusText}`);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,7 +31,7 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
-    "app/api/auth/[...nextauth]/route.js"
+    "app/api/auth/[...nextauth]/route.ts"
   ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Related to issue #23 
Related to issue #24 

This PR introduces first interaction with the AnnoRepo API in the form of a deletion button and ensure user signup following a given list of users.

- [x] add checkbox filter option with `iconography` and `textspotting`
- [x] add Auth Nextjs check
~- [ ] add server actions to check user when editing~
- [x] link annotation removing for only useres with access
- [x] add AnnoRepo write API link
- [x] add deletion possibility (also with trash icon on the annotations directly)
- [x] work on deleted annotation and its overlay without full refresh
~- [ ] add edit feature and add new features~ moved to a new PR to only focus on the editing of the annoations

<img width="497" alt="Screenshot 2025-05-07 at 12 21 42" src="https://github.com/user-attachments/assets/f5735d5a-437e-464b-a728-0f3e9bb81c50" />

Screenshot shows the checkbox filter option with `iconography` and `textspotting`

https://github.com/user-attachments/assets/7f451521-8969-4bc3-a998-c267647cfb16

Showing the deletion process currently logged in the console, without an API connection setup

https://github.com/user-attachments/assets/52d0d143-68ca-4732-b1c4-6b4c80972228

Sccreenrecording shows the access restriction page when a user is not allowed

https://github.com/user-attachments/assets/a5cea638-034a-42db-bd90-5cccc5f523bc

Restriction of user interaction with annotations
