### PR TITLE
Fix mobile viewer issues

### DIFF
--- a/components/AllmapsMap.tsx
+++ b/components/AllmapsMap.tsx
@@ -130,7 +130,10 @@ export default function AllmapsMap({
             onOpacityChange={setOpacity}
           />
         )}
-      <div ref={container} className="w-full h-full" />
+      <div
+        ref={container}
+        className="w-full h-full z-10 absolute top-0 left-0"
+      />
     </div>
   );
 }

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -2,7 +2,7 @@ export function Footer() {
   const year = new Date().getFullYear();
 
   return (
-    <footer className="bg-muted text-muted-foreground border-t border-border py-2 text-center text-[10px]">
+    <footer className="hidden sm:block bg-muted text-muted-foreground border-t border-border py-2 text-center text-[10px]">
       <p>© {year} Necessary Reunions. Funded by NWO OC XS.</p>
     </footer>
   );

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -5,8 +5,8 @@ import OrcidAuth from './OrcidAuth';
 export function Header() {
   return (
     <header className="bg-primary text-primary-foreground border-b border-border">
-      <div className="w-full px-2 sm:px-4 flex flex-col sm:flex-row items-center justify-between py-2 gap-2 sm:gap-0">
-        <div className="flex items-center space-x-2 w-full sm:w-auto justify-center sm:justify-start">
+      <div className="w-full px-2 sm:px-4 flex flex-row items-center justify-between py-2 gap-2 sm:gap-0">
+        <div className="flex items-center space-x-2 w-auto justify-center sm:justify-start">
           <Link href="/" aria-label="Home">
             <Image
               src="/image/recharted-logo.png"
@@ -16,9 +16,11 @@ export function Header() {
               height={32}
             />
           </Link>
-          <h1 className="text-xl sm:text-2xl font-heading text-white">re:Charted</h1>
+          <h1 className="text-xl hidden sm:block font-heading text-white">
+            re:Charted
+          </h1>
         </div>
-        <nav aria-label="Main" className="w-full sm:w-auto flex justify-center sm:justify-end">
+        <nav aria-label="Main" className="w-auto flex justify-end">
           <ul className="flex space-x-4 items-center">
             <li>
               <OrcidAuth />

--- a/components/ImageViewer.tsx
+++ b/components/ImageViewer.tsx
@@ -88,7 +88,7 @@ export function ImageViewer({
       padding: '4px 8px',
       borderRadius: '4px',
       fontSize: '12px',
-      zIndex: '1000',
+      zIndex: '20', // lowered from 1000
       pointerEvents: 'none',
     });
     document.body.appendChild(tip);
@@ -288,7 +288,7 @@ export function ImageViewer({
             Object.assign(div.style, {
               position: 'absolute',
               pointerEvents: 'auto',
-              zIndex: '1000',
+              zIndex: '20', // lowered from 1000
               clipPath: `polygon(${coords
                 .map(
                   ([cx, cy]) =>

--- a/components/ManifestViewer.tsx
+++ b/components/ManifestViewer.tsx
@@ -291,7 +291,7 @@ export function ManifestViewer() {
                   showIconography={showIconography}
                 />
               )}
-            {mobileView === 'map' && (
+            {mobileView === 'map' && !isGalleryOpen && !isInfoOpen && (
               <AllmapsMap
                 manifest={manifest}
                 currentCanvas={currentCanvasIndex}

--- a/components/ManifestViewer.tsx
+++ b/components/ManifestViewer.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { Button } from '@/components/Button';
-import { Loader2, Info, MessageSquare, Map, Images } from 'lucide-react';
+import { Loader2, Info, MessageSquare, Map, Images, Image } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { CollectionSidebar } from '@/components/CollectionSidebar';
 import { TopNavigation } from '@/components/Navbar';
@@ -21,7 +21,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@/components/Sheet';
-import { PanelLeft } from 'lucide-react';
+import { Footer } from '@/components/Footer';
 
 const AllmapsMap = dynamic(() => import('./AllmapsMap'), { ssr: false });
 const MetadataSidebar = dynamic(
@@ -301,26 +301,34 @@ export function ManifestViewer() {
 
           {/* Gallery Sheet */}
           <Sheet open={isGalleryOpen} onOpenChange={setIsGalleryOpen}>
-            <SheetContent side="bottom" className="max-h-[80vh] p-0">
+            <SheetContent
+              side="bottom"
+              className="max-h-[80vh] mb-14 p-0 flex flex-col overflow-y-auto"
+            >
               <SheetHeader>
-                <SheetTitle>Gallery</SheetTitle>
+                <SheetTitle className="ml-3 mt-2">Gallery</SheetTitle>
               </SheetHeader>
-              <CollectionSidebar
-                manifest={manifest}
-                currentCanvas={currentCanvasIndex}
-                onCanvasSelect={(idx) => {
-                  setCurrentCanvasIndex(idx);
-                  setIsGalleryOpen(false);
-                }}
-              />
+              <div className="flex-1 min-h-0 overflow-y-auto">
+                <CollectionSidebar
+                  manifest={manifest}
+                  currentCanvas={currentCanvasIndex}
+                  onCanvasSelect={(idx) => {
+                    setCurrentCanvasIndex(idx);
+                    setIsGalleryOpen(false);
+                  }}
+                />
+              </div>
             </SheetContent>
           </Sheet>
 
           {/* Info Sheet */}
           <Sheet open={isInfoOpen} onOpenChange={setIsInfoOpen}>
-            <SheetContent side="bottom" className="max-h-[80vh] p-0">
+            <SheetContent
+              side="bottom"
+              className="max-h-[90vh] overflow-y-auto p-0 mb-14"
+            >
               <SheetHeader>
-                <SheetTitle>Info</SheetTitle>
+                <SheetTitle className="ml-3 mt-2">Info</SheetTitle>
               </SheetHeader>
               <MetadataSidebar
                 manifest={manifest}
@@ -332,7 +340,7 @@ export function ManifestViewer() {
           </Sheet>
 
           {/* Mobile Bottom NavBar */}
-          <nav className="fixed bottom-0 left-0 right-0 z-50 bg-white border-t flex justify-around h-14">
+          <nav className="fixed bottom-0 left-0 right-0 z-[120] bg-white border-t flex justify-around h-14 w-full">
             <button
               className="flex flex-col items-center justify-center flex-1 text-xs"
               onClick={() => setIsGalleryOpen(true)}
@@ -346,7 +354,7 @@ export function ManifestViewer() {
               }`}
               onClick={() => setMobileView('image')}
             >
-              <PanelLeft className="h-6 w-6 mb-0.5" />
+              <Image className="h-6 w-6 mb-0.5" />
               Image
             </button>
             <button

--- a/components/ManifestViewer.tsx
+++ b/components/ManifestViewer.tsx
@@ -275,7 +275,10 @@ export function ManifestViewer() {
       {/* Mobile layout */}
       {isMobile && (
         <>
-          <div className="flex-1 relative overflow-hidden">
+          <div
+            className="relative pb-14"
+            style={{ height: 'calc(100vh - 3.5rem)', minHeight: 0 }}
+          >
             {(mobileView === 'image' || mobileView === 'annotation') &&
               currentCanvas && (
                 <ImageViewer

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { Button } from '@/components/Button';
 import { PanelLeft, PanelRight } from 'lucide-react';
 import { getLocalizedValue } from '@/lib/iiif-helpers';
+import { useIsMobile } from '@/hooks/use-mobile';
 
 interface TopNavigationProps {
   manifest: any;
@@ -17,32 +18,37 @@ export function TopNavigation({
   onToggleRightSidebar,
 }: TopNavigationProps) {
   const title = getLocalizedValue(manifest.label) || 'Untitled Manifest';
+  const isMobile = useIsMobile();
 
   return (
     <div className="border-b flex items-center justify-between px-2 sm:px-4 py-2">
       <div className="flex items-center gap-2 sm:gap-4">
-        <Button
-          variant="outline"
-          size="icon"
-          onClick={onToggleLeftSidebar}
-          className="h-8 w-8 sm:h-10 sm:w-10"
-        >
-          <PanelLeft className="h-5 w-5" />
-        </Button>
+        {!isMobile && (
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={onToggleLeftSidebar}
+            className="h-8 w-8 sm:h-10 sm:w-10"
+          >
+            <PanelLeft className="h-5 w-5" />
+          </Button>
+        )}
         <span className="font-medium truncate max-w-[120px] sm:max-w-md text-base sm:text-lg">
           {title}
         </span>
       </div>
 
       <div className="flex items-center gap-2">
-        <Button
-          variant="outline"
-          size="icon"
-          onClick={onToggleRightSidebar}
-          className="h-8 w-8 sm:h-10 sm:w-10 hidden sm:inline-flex"
-        >
-          <PanelRight className="h-5 w-5" />
-        </Button>
+        {!isMobile && (
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={onToggleRightSidebar}
+            className="h-8 w-8 sm:h-10 sm:w-10 hidden sm:inline-flex"
+          >
+            <PanelRight className="h-5 w-5" />
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -21,8 +21,8 @@ export function TopNavigation({
   const isMobile = useIsMobile();
 
   return (
-    <div className="border-b flex items-center justify-between px-2 sm:px-4 py-2">
-      <div className="flex items-center gap-2 sm:gap-4">
+    <div className="border-b flex items-center justify-between px-2 py-2">
+      <div className="flex items-center gap-2 sm:gap-0 sm:justify-start md:flex-none">
         {!isMobile && (
           <Button
             variant="outline"

--- a/components/OrcidAuth.tsx
+++ b/components/OrcidAuth.tsx
@@ -43,7 +43,9 @@ export default function OrcidAuth() {
           <span className="text-sm text-white">
             {(session.user as SessionUser)?.label}
             <br />
-            <small>ORCID: {(session.user as SessionUser)?.id}</small>
+            <small className="hidden sm:block">
+              ORCID: {(session.user as SessionUser)?.id}
+            </small>
           </span>
           <Button
             onClick={() => signOut()}

--- a/components/Sheet.tsx
+++ b/components/Sheet.tsx
@@ -18,7 +18,7 @@ export const SheetOverlay = React.forwardRef<
   <RadixSheet.Overlay
     ref={ref}
     className={cn(
-      'fixed inset-0 z-50 bg-black/80',
+      'fixed inset-0 z-[100] bg-black/80',
       'data-[state=open]:animate-in data-[state=closed]:animate-out',
       'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
       className,
@@ -29,7 +29,7 @@ export const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = RadixSheet.Overlay.displayName;
 
 const sheetVariants = cva(
-  'fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out',
+  'fixed z-[110] gap-4 bg-background p-6 shadow-lg transition ease-in-out',
   {
     variants: {
       side: {


### PR DESCRIPTION
This PR fixes the issues with the mobile view and closes issue #32 

- [x] Fix overlay problem of the Mobile Bottom NavBar
- [x] Fix overlay problem with the annotations and leaflet container with the Info and Gallery Sheet
- [x] Adjust icons in mobile view
- [x] Adjust header in mobile view to be one line
- [x] Disable the Sidebar icons in the NavBar component when in mobile view

*Screenshot 1*: Shows the adjusted mobile view with the signed in user in one line with the logo in the header, the collection name without any additional icons and the change image viewer icon in the bottom navbar
![Screenshot 2025-05-20 at 14 19 38](https://github.com/user-attachments/assets/f86bc0ef-0299-44b1-a685-aa48b4fbe132)

*Screenshot 2*: Shows the working info panel overlay, without having overlay problems with the annotations and leaflet conatiner
![Screenshot 2025-05-20 at 14 20 11](https://github.com/user-attachments/assets/7eab18e4-4f87-4c1f-9731-4b5f7ee78c86)

*Screenshot 3*: Shows the same as screenshot 2 but for the gallery viewer overlay
![Screenshot 2025-05-20 at 14 19 48](https://github.com/user-attachments/assets/3779e38c-4cc9-4d41-be05-6da4c38b8893)

