### PR TITLE
Add manifest loading switcher

### DIFF
--- a/app/api/proxy-image/route.ts
+++ b/app/api/proxy-image/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const url = searchParams.get('url');
+
+  if (!url) {
+    return new NextResponse('Missing URL parameter', { status: 400 });
+  }
+
+  try {
+    const parsedUrl = new URL(url);
+    if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+      return new NextResponse('Invalid URL protocol', { status: 400 });
+    }
+
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent': 'IIIF-Viewer/1.0',
+      },
+    });
+
+    if (!response.ok) {
+      return new NextResponse(`Failed to fetch image: ${response.statusText}`, {
+        status: response.status,
+      });
+    }
+
+    const imageBuffer = await response.arrayBuffer();
+    const contentType = response.headers.get('content-type') || 'image/jpeg';
+
+    return new NextResponse(imageBuffer, {
+      headers: {
+        'Content-Type': contentType,
+        'Cache-Control': 'public, max-age=3600',
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET',
+        'Access-Control-Allow-Headers': 'Content-Type',
+      },
+    });
+  } catch (error) {
+    console.error('Error proxying image:', error);
+    return new NextResponse('Failed to proxy image', { status: 500 });
+  }
+}

--- a/app/loader/page.tsx
+++ b/app/loader/page.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { ManifestViewer } from '@/components/ManifestViewer';
+import { useRouter } from 'next/navigation';
+
+export default function LoaderPage() {
+  const router = useRouter();
+
+  const handleClose = () => {
+    router.push('/');
+  };
+
+  return (
+    <div className="h-full flex flex-col overflow-hidden">
+      <ManifestViewer
+        showManifestLoader={true}
+        onManifestLoaderClose={handleClose}
+      />
+    </div>
+  );
+}

--- a/components/CollectionView.tsx
+++ b/components/CollectionView.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent } from '@/components/Card';
 import { Badge } from '@/components/Badge';
 import { ScrollArea } from '@/components/ScrollArea';
 import { Map, MessageSquare } from 'lucide-react';
-import { getLocalizedValue } from '@/lib/iiif-helpers';
+import { getLocalizedValue, getManifestCanvases } from '@/lib/iiif-helpers';
 import { cn } from '@/lib/utils';
 
 interface CollectionViewProps {
@@ -22,7 +22,7 @@ export function CollectionView({
   onImageDoubleClick,
 }: CollectionViewProps) {
   const [hovered, setHovered] = useState<number | null>(null);
-  const canvases = manifest.items || [];
+  const canvases = getManifestCanvases(manifest);
 
   const hasGeo = (canvas: any) =>
     !!canvas?.annotations?.some((page: any) =>

--- a/components/Dialog.tsx
+++ b/components/Dialog.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className,
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      'flex flex-col space-y-1.5 text-center sm:text-left',
+      className,
+    )}
+    {...props}
+  />
+);
+DialogHeader.displayName = 'DialogHeader';
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+      className,
+    )}
+    {...props}
+  />
+);
+DialogFooter.displayName = 'DialogFooter';
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      'text-lg font-semibold leading-none tracking-tight',
+      className,
+    )}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-muted-foreground', className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+};

--- a/components/ImageViewer.tsx
+++ b/components/ImageViewer.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import { cn } from '@/lib/utils';
+import { getManifestCanvases, getCanvasImageInfo } from '@/lib/iiif-helpers';
 import type { Annotation } from '@/lib/types';
 import { LoadingSpinner } from './LoadingSpinner';
 
@@ -97,7 +98,8 @@ export function ImageViewer({
 
   useEffect(() => {
     const container = mountRef.current;
-    const canvas = manifest?.items?.[currentCanvas];
+    const canvases = getManifestCanvases(manifest);
+    const canvas = canvases[currentCanvas];
     if (!container || !canvas) return;
 
     setLoading(true);
@@ -113,23 +115,7 @@ export function ImageViewer({
     overlaysRef.current = [];
     vpRectsRef.current = {};
 
-    const items = canvas.items?.[0]?.items || [];
-    const { service, url } = items.reduce(
-      (acc: any, { body, motivation }: any) => {
-        if (!acc.service && body?.service)
-          acc.service = Array.isArray(body.service)
-            ? body.service[0]
-            : body.service;
-        if (
-          !acc.url &&
-          body?.id &&
-          (body.type === 'Image' || motivation === 'painting')
-        )
-          acc.url = body.id;
-        return acc;
-      },
-      { service: null, url: null },
-    );
+    const { service, url } = getCanvasImageInfo(canvas);
 
     if (!service && !url) {
       setLoading(false);

--- a/components/ManifestLoader.tsx
+++ b/components/ManifestLoader.tsx
@@ -1,0 +1,372 @@
+'use client';
+
+import React, { useState, useCallback } from 'react';
+import { Button } from '@/components/Button';
+import { Input } from '@/components/Input';
+import { Label } from '@/components/Label';
+import { Textarea } from '@/components/Textarea';
+import { Card } from '@/components/Card';
+import { Upload, Link, FileText, Loader2, ExternalLink } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
+import type { Manifest } from '@/lib/types';
+
+interface ManifestLoaderProps {
+  currentManifest?: Manifest | null;
+  onManifestLoad: (manifest: Manifest) => void;
+  onClose: () => void;
+}
+
+export function ManifestLoader({
+  currentManifest,
+  onManifestLoad,
+  onClose,
+}: ManifestLoaderProps) {
+  const [manifestUrl, setManifestUrl] = useState('');
+  const [manifestJson, setManifestJson] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [activeTab, setActiveTab] = useState<'url' | 'file' | 'json'>('url');
+  const { toast } = useToast();
+
+  const loadDefaultManifest = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      // Try local API first
+      let res = await fetch('/api/manifest');
+      if (!res.ok) {
+        // Fallback to static manifest
+        res = await fetch(
+          'https://globalise-huygens.github.io/necessary-reunions/manifest.json',
+        );
+      }
+      if (!res.ok) throw new Error(`Status ${res.status}`);
+
+      const data = await res.json();
+      onManifestLoad(data);
+      toast({
+        title: 'Default manifest loaded',
+        description: data.label?.en?.[0] || 'Necessary Reunions Collection',
+      });
+      onClose();
+    } catch (err: any) {
+      const msg = err?.message || 'Unknown error';
+      toast({ title: 'Failed to load default manifest', description: msg });
+    } finally {
+      setIsLoading(false);
+    }
+  }, [onManifestLoad, onClose, toast]);
+
+  const loadManifestFromUrl = useCallback(async () => {
+    if (!manifestUrl.trim()) {
+      toast({ title: 'Please enter a valid URL' });
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const res = await fetch(manifestUrl);
+      if (!res.ok) throw new Error(`Status ${res.status}`);
+
+      const data = await res.json();
+
+      // Basic IIIF manifest validation for both v2 and v3
+      const isV2 =
+        data['@context'] && data['@context'].includes('api/presentation/2');
+      const isV3 =
+        data['@context'] && data['@context'].includes('api/presentation/3');
+
+      if (!isV2 && !isV3 && !data.type) {
+        throw new Error('Invalid IIIF manifest format');
+      }
+
+      // Check if manifest has content (canvases)
+      const hasContent =
+        (isV3 && data.items) || (isV2 && data.sequences?.[0]?.canvases);
+      if (!hasContent) {
+        throw new Error('Manifest contains no viewable content');
+      }
+
+      onManifestLoad(data);
+      toast({
+        title: 'Manifest loaded from URL',
+        description: data.label?.en?.[0] || data.label || 'Remote manifest',
+      });
+      onClose();
+    } catch (err: any) {
+      const msg = err?.message || 'Unknown error';
+      toast({ title: 'Failed to load manifest from URL', description: msg });
+    } finally {
+      setIsLoading(false);
+    }
+  }, [manifestUrl, onManifestLoad, onClose, toast]);
+
+  const loadManifestFromJson = useCallback(async () => {
+    if (!manifestJson.trim()) {
+      toast({ title: 'Please enter valid JSON' });
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const data = JSON.parse(manifestJson);
+
+      // Basic IIIF manifest validation for both v2 and v3
+      const isV2 =
+        data['@context'] && data['@context'].includes('api/presentation/2');
+      const isV3 =
+        data['@context'] && data['@context'].includes('api/presentation/3');
+
+      if (!isV2 && !isV3 && !data.type) {
+        throw new Error('Invalid IIIF manifest format');
+      }
+
+      // Check if manifest has content (canvases)
+      const hasContent =
+        (isV3 && data.items) || (isV2 && data.sequences?.[0]?.canvases);
+      if (!hasContent) {
+        throw new Error('Manifest contains no viewable content');
+      }
+
+      onManifestLoad(data);
+      toast({
+        title: 'Manifest loaded from JSON',
+        description: data.label?.en?.[0] || data.label || 'Custom manifest',
+      });
+      onClose();
+    } catch (err: any) {
+      const msg = err?.message || 'Invalid JSON or manifest format';
+      toast({ title: 'Failed to parse manifest', description: msg });
+    } finally {
+      setIsLoading(false);
+    }
+  }, [manifestJson, onManifestLoad, onClose, toast]);
+
+  const handleFileUpload = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      if (!file) return;
+
+      if (file.type !== 'application/json' && !file.name.endsWith('.json')) {
+        toast({ title: 'Please select a JSON file' });
+        return;
+      }
+
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        const content = e.target?.result as string;
+        if (content) {
+          setManifestJson(content);
+          setActiveTab('json');
+        }
+      };
+      reader.readAsText(file);
+    },
+    [toast],
+  );
+
+  return (
+    <div className="space-y-6">
+      {/* Current Manifest Info */}
+      {currentManifest && (
+        <Card className="p-4 bg-muted/50">
+          <div className="flex items-center gap-2 mb-2">
+            <FileText className="h-4 w-4" />
+            <span className="font-medium">Current Manifest</span>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            {typeof currentManifest.label === 'string'
+              ? currentManifest.label
+              : currentManifest.label?.en?.[0] || 'Untitled Manifest'}
+          </p>
+          <p className="text-xs text-muted-foreground mt-1">
+            {currentManifest.items?.length || 0} items
+          </p>
+        </Card>
+      )}
+
+      {/* Default Manifest */}
+      <div>
+        <Button
+          onClick={loadDefaultManifest}
+          disabled={isLoading}
+          className="w-full"
+          variant="outline"
+        >
+          {isLoading ? (
+            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+          ) : (
+            <FileText className="h-4 w-4 mr-2" />
+          )}
+          Load Default Manifest (Necessary Reunions)
+        </Button>
+      </div>
+
+      {/* Tab Navigation */}
+      <div className="flex border-b">
+        <button
+          className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+            activeTab === 'url'
+              ? 'border-primary text-primary'
+              : 'border-transparent text-muted-foreground hover:text-foreground'
+          }`}
+          onClick={() => setActiveTab('url')}
+        >
+          <Link className="h-4 w-4 mr-1 inline" />
+          From URL
+        </button>
+        <button
+          className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+            activeTab === 'file'
+              ? 'border-primary text-primary'
+              : 'border-transparent text-muted-foreground hover:text-foreground'
+          }`}
+          onClick={() => setActiveTab('file')}
+        >
+          <Upload className="h-4 w-4 mr-1 inline" />
+          Upload File
+        </button>
+        <button
+          className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+            activeTab === 'json'
+              ? 'border-primary text-primary'
+              : 'border-transparent text-muted-foreground hover:text-foreground'
+          }`}
+          onClick={() => setActiveTab('json')}
+        >
+          <FileText className="h-4 w-4 mr-1 inline" />
+          Paste JSON
+        </button>
+      </div>
+
+      {/* Tab Content */}
+      <div className="space-y-4">
+        {activeTab === 'url' && (
+          <div className="space-y-4">
+            <div>
+              <Label htmlFor="manifest-url">Manifest URL</Label>
+              <Input
+                id="manifest-url"
+                type="url"
+                placeholder="https://example.com/manifest.json"
+                value={manifestUrl}
+                onChange={(e) => setManifestUrl(e.target.value)}
+                className="mt-1"
+              />
+              <p className="text-xs text-muted-foreground mt-1">
+                Enter the URL of a IIIF manifest.json file
+              </p>
+            </div>
+            <Button
+              onClick={loadManifestFromUrl}
+              disabled={isLoading || !manifestUrl.trim()}
+              className="w-full"
+            >
+              {isLoading ? (
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+              ) : (
+                <ExternalLink className="h-4 w-4 mr-2" />
+              )}
+              Load from URL
+            </Button>
+          </div>
+        )}
+
+        {activeTab === 'file' && (
+          <div className="space-y-4">
+            <div>
+              <Label htmlFor="manifest-file">Upload Manifest File</Label>
+              <Input
+                id="manifest-file"
+                type="file"
+                accept=".json,application/json"
+                onChange={handleFileUpload}
+                className="mt-1"
+              />
+              <p className="text-xs text-muted-foreground mt-1">
+                Select a IIIF manifest.json file from your computer
+              </p>
+            </div>
+          </div>
+        )}
+
+        {activeTab === 'json' && (
+          <div className="space-y-4">
+            <div>
+              <Label htmlFor="manifest-json">Manifest JSON</Label>
+              <Textarea
+                id="manifest-json"
+                placeholder="Paste your IIIF manifest JSON here..."
+                value={manifestJson}
+                onChange={(e) => setManifestJson(e.target.value)}
+                className="mt-1 min-h-[200px] font-mono text-sm"
+              />
+              <p className="text-xs text-muted-foreground mt-1">
+                Paste the contents of a IIIF manifest.json file
+              </p>
+            </div>
+            <Button
+              onClick={loadManifestFromJson}
+              disabled={isLoading || !manifestJson.trim()}
+              className="w-full"
+            >
+              {isLoading ? (
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+              ) : (
+                <FileText className="h-4 w-4 mr-2" />
+              )}
+              Load from JSON
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {/* Sample Manifests */}
+      <div className="space-y-2">
+        <Label className="text-sm font-medium">Sample Manifests</Label>
+        <div className="space-y-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="w-full justify-start text-xs h-8"
+            onClick={() => {
+              setManifestUrl(
+                'https://iiif.io/api/cookbook/recipe/0001-mvm-image/manifest.json',
+              );
+              setActiveTab('url');
+            }}
+          >
+            <ExternalLink className="h-3 w-3 mr-2" />
+            IIIF Cookbook - Simple Image
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="w-full justify-start text-xs h-8"
+            onClick={() => {
+              setManifestUrl(
+                'https://iiif.io/api/cookbook/recipe/0005-image-service/manifest.json',
+              );
+              setActiveTab('url');
+            }}
+          >
+            <ExternalLink className="h-3 w-3 mr-2" />
+            IIIF Cookbook - Image Service
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="w-full justify-start text-xs h-8"
+            onClick={() => {
+              setManifestUrl(
+                'https://uvaerfgoed.nl/viewer/api/v1/records/11245_3_2556/manifest/',
+              );
+              setActiveTab('url');
+            }}
+          >
+            <ExternalLink className="h-3 w-3 mr-2" />
+            UVA Heritage - Dutch Map (IIIF v2)
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/ManifestViewer.tsx
+++ b/components/ManifestViewer.tsx
@@ -7,6 +7,7 @@ import { useToast } from '@/hooks/use-toast';
 import { CollectionSidebar } from '@/components/CollectionSidebar';
 import { TopNavigation } from '@/components/Navbar';
 import { StatusBar } from '@/components/StatusBar';
+import { normalizeManifest, getManifestCanvases } from '@/lib/iiif-helpers';
 import dynamic from 'next/dynamic';
 import type { Manifest } from '@/lib/types';
 import { ImageViewer } from '@/components/ImageViewer';
@@ -21,6 +22,14 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@/components/Sheet';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/Dialog';
+import { ManifestLoader } from '@/components/ManifestLoader';
 import { Footer } from '@/components/Footer';
 
 const AllmapsMap = dynamic(() => import('./AllmapsMap'), { ssr: false });
@@ -29,7 +38,15 @@ const MetadataSidebar = dynamic(
   { ssr: true },
 );
 
-export function ManifestViewer() {
+interface ManifestViewerProps {
+  showManifestLoader?: boolean;
+  onManifestLoaderClose?: () => void;
+}
+
+export function ManifestViewer({
+  showManifestLoader = false,
+  onManifestLoaderClose,
+}: ManifestViewerProps) {
   const [manifest, setManifest] = useState<Manifest | null>(null);
   const [isLoadingManifest, setIsLoadingManifest] = useState(true);
   const [manifestError, setManifestError] = useState<string | null>(null);
@@ -51,7 +68,8 @@ export function ManifestViewer() {
   const [showIconography, setShowIconography] = useState(true);
 
   const [localAnnotations, setLocalAnnotations] = useState<Annotation[]>([]);
-  const canvasId = manifest?.items?.[currentCanvasIndex]?.id ?? '';
+  const canvasId =
+    getManifestCanvases(manifest)?.[currentCanvasIndex]?.id ?? '';
   const { annotations, isLoading: isLoadingAnnotations } =
     useAllAnnotations(canvasId);
 
@@ -61,6 +79,15 @@ export function ManifestViewer() {
   >('image');
   const [isGalleryOpen, setIsGalleryOpen] = useState(false);
   const [isInfoOpen, setIsInfoOpen] = useState(false);
+  const [isManifestLoaderOpen, setIsManifestLoaderOpen] =
+    useState(showManifestLoader);
+
+  const handleManifestLoaderClose = () => {
+    setIsManifestLoaderOpen(false);
+    if (onManifestLoaderClose) {
+      onManifestLoaderClose();
+    }
+  };
 
   useEffect(() => {
     setLocalAnnotations(annotations);
@@ -78,7 +105,8 @@ export function ManifestViewer() {
       const res = await fetch('/api/manifest');
       if (!res.ok) throw new Error(`Status ${res.status}`);
       const data = await res.json();
-      setManifest(data);
+      const normalizedData = normalizeManifest(data);
+      setManifest(normalizedData);
       toast({ title: 'Manifest loaded', description: data.label?.en?.[0] });
     } catch {
       try {
@@ -87,7 +115,8 @@ export function ManifestViewer() {
         );
         if (!res.ok) throw new Error(`Status ${res.status}`);
         const data = await res.json();
-        setManifest(data);
+        const normalizedData = normalizeManifest(data);
+        setManifest(normalizedData);
         toast({
           title: 'Static manifest loaded',
           description: data.label?.en?.[0],
@@ -132,7 +161,7 @@ export function ManifestViewer() {
     );
   }
 
-  const currentCanvas = manifest.items[currentCanvasIndex];
+  const currentCanvas = getManifestCanvases(manifest)?.[currentCanvasIndex];
 
   const handleDelete = async (annotation: Annotation) => {
     const annoName = annotation.id.split('/').pop()!;
@@ -161,6 +190,7 @@ export function ManifestViewer() {
         manifest={manifest}
         onToggleLeftSidebar={() => setIsLeftSidebarVisible((p) => !p)}
         onToggleRightSidebar={() => setIsRightSidebarVisible((p) => !p)}
+        onOpenManifestLoader={() => setIsManifestLoaderOpen(true)}
       />
 
       {/* Desktop layout */}
@@ -265,7 +295,7 @@ export function ManifestViewer() {
           <StatusBar
             manifest={manifest}
             currentCanvas={currentCanvasIndex}
-            totalCanvases={manifest.items.length}
+            totalCanvases={getManifestCanvases(manifest).length}
             onCanvasChange={setCurrentCanvasIndex}
             viewMode={viewMode === 'annotation' ? undefined : viewMode}
           />
@@ -388,6 +418,36 @@ export function ManifestViewer() {
           </nav>
         </>
       )}
+
+      {/* Manifest Loader Dialog */}
+      <Dialog
+        open={isManifestLoaderOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            handleManifestLoaderClose();
+          }
+        }}
+      >
+        <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Load IIIF Manifest</DialogTitle>
+            <DialogDescription>
+              Load a different IIIF manifest to view and work with.
+            </DialogDescription>
+          </DialogHeader>
+          <ManifestLoader
+            currentManifest={manifest}
+            onManifestLoad={(newManifest) => {
+              const normalizedManifest = normalizeManifest(newManifest);
+              setManifest(normalizedManifest);
+              setCurrentCanvasIndex(0);
+              setSelectedAnnotationId(null);
+              handleManifestLoaderClose();
+            }}
+            onClose={handleManifestLoaderClose}
+          />
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { Button } from '@/components/Button';
-import { PanelLeft, PanelRight } from 'lucide-react';
+import { PanelLeft, PanelRight, Folder } from 'lucide-react';
 import { getLocalizedValue } from '@/lib/iiif-helpers';
 import { useIsMobile } from '@/hooks/use-mobile';
 
@@ -10,12 +10,14 @@ interface TopNavigationProps {
   manifest: any;
   onToggleLeftSidebar: () => void;
   onToggleRightSidebar: () => void;
+  onOpenManifestLoader?: () => void;
 }
 
 export function TopNavigation({
   manifest,
   onToggleLeftSidebar,
   onToggleRightSidebar,
+  onOpenManifestLoader,
 }: TopNavigationProps) {
   const title = getLocalizedValue(manifest.label) || 'Untitled Manifest';
   const isMobile = useIsMobile();
@@ -39,6 +41,18 @@ export function TopNavigation({
       </div>
 
       <div className="flex items-center gap-2">
+        {onOpenManifestLoader && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onOpenManifestLoader}
+            className="h-8 px-2 sm:h-10 sm:px-3"
+            title="Load different manifest"
+          >
+            <Folder className="h-4 w-4 mr-1" />
+            <span className="hidden sm:inline">Load</span>
+          </Button>
+        )}
         {!isMobile && (
           <Button
             variant="outline"

--- a/lib/iiif-helpers.ts
+++ b/lib/iiif-helpers.ts
@@ -23,23 +23,16 @@ export function getLocalizedValue(languageMap: any, preferredLanguage = 'en') {
   return null;
 }
 
-/**
- * Normalizes IIIF v2 and v3 manifests to a consistent v3-like structure
- */
 export function normalizeManifest(manifest: any): Manifest {
-  // If it's already v3, return as is
   if (manifest.items) {
     return manifest;
   }
 
-  // Convert v2 to v3-like structure
   const normalized = { ...manifest };
 
-  // Convert sequences to items
   if (manifest.sequences?.[0]?.canvases) {
     normalized.items = manifest.sequences[0].canvases.map((canvas: any) => ({
       ...canvas,
-      // Ensure we have the basic v3 structure
       type:
         canvas['@type'] === 'sc:Canvas' ? 'Canvas' : canvas.type || 'Canvas',
       id: canvas['@id'] || canvas.id,
@@ -49,28 +42,21 @@ export function normalizeManifest(manifest: any): Manifest {
   return normalized as Manifest;
 }
 
-/**
- * Gets the canvases from a manifest, handling both v2 and v3 formats
- */
 export function getManifestCanvases(manifest: any) {
   if (!manifest) return [];
 
   if (manifest.items) {
-    return manifest.items; // v3
+    return manifest.items;
   }
   if (manifest.sequences?.[0]?.canvases) {
-    return manifest.sequences[0].canvases; // v2
+    return manifest.sequences[0].canvases;
   }
   return [];
 }
 
-/**
- * Extracts image service and URL from a canvas, handling both IIIF v2 and v3 formats
- */
 export function getCanvasImageInfo(canvas: any) {
   if (!canvas) return { service: null, url: null };
 
-  // IIIF v3 format
   if (canvas.items) {
     const items = canvas.items?.[0]?.items || [];
     return items.reduce(
@@ -93,7 +79,6 @@ export function getCanvasImageInfo(canvas: any) {
     );
   }
 
-  // IIIF v2 format
   if (canvas.images) {
     const image = canvas.images[0];
     if (image?.resource) {


### PR DESCRIPTION
This PR adds a manifest loader button and overlay window to the tool, to enable the switching between manifest.jsons, also via url entry.

The button in the tool
<img width="1710" alt="Screenshot 2025-06-18 at 15 43 41" src="https://github.com/user-attachments/assets/c917a46b-0cd2-44a6-8043-d74c7b92aa68" />

The overlay window:
<img width="783" alt="Screenshot 2025-06-18 at 15 43 47" src="https://github.com/user-attachments/assets/fc237016-ae46-45d5-b625-ddfba937d76c" />
