### PR TITLE
Stablise manifest loading

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": [
+    "next/core-web-vitals",
+    "next/typescript"
+  ]
+}

--- a/app/api/annotations/local/route.ts
+++ b/app/api/annotations/local/route.ts
@@ -1,0 +1,45 @@
+import fs from 'fs';
+import { NextResponse } from 'next/server';
+import path from 'path';
+
+export async function GET() {
+  try {
+    const annotationsDir = path.join(
+      process.cwd(),
+      'data',
+      'annotations',
+      'georeferencing',
+    );
+
+    if (!fs.existsSync(annotationsDir)) {
+      return NextResponse.json({ annotations: [] });
+    }
+
+    const files = fs
+      .readdirSync(annotationsDir)
+      .filter((file) => file.endsWith('.json'));
+    const annotations: any[] = [];
+
+    for (const file of files) {
+      try {
+        const filePath = path.join(annotationsDir, file);
+        const content = fs.readFileSync(filePath, 'utf8');
+        const annotationPage = JSON.parse(content);
+
+        if (annotationPage.items && Array.isArray(annotationPage.items)) {
+          annotations.push(...annotationPage.items);
+        }
+      } catch (error) {
+        console.error(`Error reading annotation file ${file}:`, error);
+      }
+    }
+
+    return NextResponse.json({ annotations });
+  } catch (error) {
+    console.error('Error loading local annotations:', error);
+    return NextResponse.json(
+      { error: 'Failed to load local annotations' },
+      { status: 500 },
+    );
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,13 +1,12 @@
-import { Lexend, Roboto } from 'next/font/google';
 import 'leaflet/dist/leaflet.css';
 import './globals.css';
-
-import { Toaster } from '@/components/Toaster';
-import { Header } from '@/components/Header';
 import { Footer } from '@/components/Footer';
+import { Header } from '@/components/Header';
+import { Toaster } from '@/components/Toaster';
+import type { Metadata } from 'next';
+import { Lexend, Roboto } from 'next/font/google';
 import { Providers } from './providers';
 import { SessionProviderWrapper } from './SessionProviderWrapper';
-import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
   title: 're:Charted – IIIF Viewer and Editor',
@@ -58,6 +57,7 @@ export default function RootLayout({
     <html lang="en">
       <body
         className={`${lexend.variable} ${roboto.variable} font-body bg-white text-foreground antialiased grid grid-rows-[auto_1fr_auto] h-full overflow-hidden`}
+        suppressHydrationWarning={true}
       >
         <SessionProviderWrapper>
           <Providers>

--- a/components/AllmapsMap.tsx
+++ b/components/AllmapsMap.tsx
@@ -88,6 +88,11 @@ export default function AllmapsMap({
     const markersPane = map.getPane('markersPane')!;
     markersPane.style.zIndex = '1002';
 
+    const popupPane = map.getPane('popupPane');
+    if (popupPane) {
+      popupPane.style.zIndex = '1100';
+    }
+
     const canvas = map.getContainer().querySelector('canvas');
     if (canvas) {
       const gl =
@@ -441,6 +446,18 @@ export default function AllmapsMap({
         }
         .leaflet-pane.leaflet-marker-pane {
           z-index: 1003 !important;
+        }
+        .leaflet-popup-pane {
+          z-index: 1100 !important;
+        }
+        .leaflet-popup {
+          z-index: 1100 !important;
+        }
+        .leaflet-popup-content-wrapper {
+          z-index: 1100 !important;
+        }
+        .leaflet-popup-tip {
+          z-index: 1100 !important;
         }
       `}</style>
 

--- a/components/AllmapsMap.tsx
+++ b/components/AllmapsMap.tsx
@@ -29,6 +29,36 @@ export default function AllmapsMap({
   const [loadedMapsCount, setLoadedMapsCount] = useState(0);
 
   useEffect(() => {
+    const containerElement = container.current;
+    if (!containerElement || !mapRef.current) return;
+
+    const resizeObserver = new ResizeObserver(() => {
+      if (mapRef.current) {
+        setTimeout(() => {
+          mapRef.current?.invalidateSize();
+        }, 10);
+      }
+    });
+
+    resizeObserver.observe(containerElement);
+
+    const handleWindowResize = () => {
+      if (mapRef.current) {
+        setTimeout(() => {
+          mapRef.current?.invalidateSize();
+        }, 10);
+      }
+    };
+
+    window.addEventListener('resize', handleWindowResize);
+
+    return () => {
+      resizeObserver.disconnect();
+      window.removeEventListener('resize', handleWindowResize);
+    };
+  }, [initialized]);
+
+  useEffect(() => {
     if (!container.current || mapRef.current) return;
 
     const map = L.map(container.current, { center: [9.9, 76.4], zoom: 8 });
@@ -86,6 +116,11 @@ export default function AllmapsMap({
     if (pane) pane.style.opacity = opacity.toString();
 
     setInitialized(true);
+
+    // Ensure proper sizing after initialization
+    setTimeout(() => {
+      map.invalidateSize();
+    }, 100);
 
     return () => {
       if (warpedRef.current) {

--- a/components/AllmapsMap.tsx
+++ b/components/AllmapsMap.tsx
@@ -369,14 +369,14 @@ export default function AllmapsMap({
     <div className="relative w-full h-full pb-14 sm:pb-0">
       <style jsx>{`
         .gcp-marker {
-          z-index: 10000 !important;
+          z-index: 1000 !important;
           pointer-events: auto !important;
         }
         .marker-wrapper {
           filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.2));
         }
         .leaflet-marker-icon {
-          z-index: 10000 !important;
+          z-index: 1000 !important;
         }
         .leaflet-pane.leaflet-marker-pane {
           z-index: 1003 !important;

--- a/components/CollectionSidebar.tsx
+++ b/components/CollectionSidebar.tsx
@@ -1,18 +1,18 @@
 'use client';
 
-import * as React from 'react';
-import { ScrollArea } from '@/components/ScrollArea';
 import { Badge } from '@/components/Badge';
-import {
-  Map,
-  MessageSquare,
-  Calendar,
-  User,
-  Building,
-  Ruler,
-} from 'lucide-react';
+import { ScrollArea } from '@/components/ScrollArea';
 import { getLocalizedValue, getManifestCanvases } from '@/lib/iiif-helpers';
 import { cn } from '@/lib/utils';
+import {
+  Building,
+  Calendar,
+  Map,
+  MessageSquare,
+  Ruler,
+  User,
+} from 'lucide-react';
+import * as React from 'react';
 
 interface CollectionSidebarProps {
   manifest: any;
@@ -37,15 +37,23 @@ export function CollectionSidebar({
   };
 
   const hasAnnotations = (canvas: any): boolean => {
-    const hasItems = canvas.items
-      ?.flatMap((page: any) => page.items ?? [])
-      .some((anno: any) => anno.motivation === 'painting');
-
     const hasAnnotationPages = canvas.annotations?.some((page: any) =>
-      page.items?.some((anno: any) => Boolean(anno.motivation)),
+      page.items?.some((anno: any) => {
+        if (!anno.motivation) return false;
+
+        if (typeof anno.motivation === 'string') {
+          return anno.motivation !== 'painting';
+        }
+
+        if (Array.isArray(anno.motivation)) {
+          return anno.motivation.some((m: string) => m !== 'painting');
+        }
+
+        return false;
+      }),
     );
 
-    return hasItems || hasAnnotationPages;
+    return hasAnnotationPages;
   };
 
   const getThumbnailUrl = (canvas: any): string | null => {
@@ -277,7 +285,7 @@ export function CollectionSidebar({
                             className="text-[10px] py-0.5 h-auto flex items-center gap-1"
                           >
                             <Map className="h-2.5 w-2.5" />
-                            Georeferenced
+                            Geo
                           </Badge>
                         )}
                         {hasAnno && (
@@ -286,7 +294,7 @@ export function CollectionSidebar({
                             className="text-[10px] py-0.5 h-auto flex items-center gap-1"
                           >
                             <MessageSquare className="h-2.5 w-2.5" />
-                            Annotated
+                            Anno
                           </Badge>
                         )}
                       </div>

--- a/components/CollectionSidebar.tsx
+++ b/components/CollectionSidebar.tsx
@@ -20,40 +20,28 @@ interface CollectionSidebarProps {
   onCanvasSelect: (index: number) => void;
 }
 
-export function CollectionSidebar({
-  manifest,
+interface CanvasItemProps {
+  canvas: any;
+  index: number;
+  currentCanvas: number;
+  onCanvasSelect: (index: number) => void;
+  hasAnnotations: boolean;
+}
+
+function CanvasItem({
+  canvas,
+  index,
   currentCanvas,
   onCanvasSelect,
-}: CollectionSidebarProps) {
-  const canvases = getManifestCanvases(manifest);
-
-  const isGeoreferenced = (canvas: any): boolean => {
+  hasAnnotations: hasAnno,
+}: CanvasItemProps) {
+  const isGeoreferenced = (): boolean => {
     return !!(
       canvas.navPlace?.features?.length > 0 ||
       canvas.annotations?.some((page: any) =>
         page.id?.toLowerCase().includes('georeferencing'),
       )
     );
-  };
-
-  const hasAnnotations = (canvas: any): boolean => {
-    const hasAnnotationPages = canvas.annotations?.some((page: any) =>
-      page.items?.some((anno: any) => {
-        if (!anno.motivation) return false;
-
-        if (typeof anno.motivation === 'string') {
-          return anno.motivation !== 'painting';
-        }
-
-        if (Array.isArray(anno.motivation)) {
-          return anno.motivation.some((m: string) => m !== 'painting');
-        }
-
-        return false;
-      }),
-    );
-
-    return hasAnnotationPages;
   };
 
   const getThumbnailUrl = (canvas: any): string | null => {
@@ -165,6 +153,198 @@ export function CollectionSidebar({
     </div>
   );
 
+  const thumbnailUrl = getThumbnailUrl(canvas);
+  const isGeo = isGeoreferenced();
+  const isSelected = index === currentCanvas;
+  const label = getLocalizedValue(canvas.label) || `Image ${index + 1}`;
+  const metadata = getCanvasMetadata(canvas);
+  const dimensions = formatDimensions(canvas);
+
+  return (
+    <li key={index}>
+      <div
+        className={cn(
+          'group flex items-start gap-3 p-3 rounded-lg cursor-pointer transition-all',
+          'border border-transparent hover:border-border/50',
+          'focus-within:outline-none focus-within:ring-2 focus-within:ring-primary/20',
+          isSelected && 'bg-primary/10 border-primary/30 shadow-sm',
+        )}
+        onClick={() => onCanvasSelect(index)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onCanvasSelect(index);
+          }
+        }}
+        tabIndex={0}
+        role="button"
+        aria-pressed={isSelected}
+        aria-label={`Select ${label}${isGeo ? ', georeferenced' : ''}${
+          hasAnno ? ', annotated' : ''
+        }`}
+      >
+        <div className="relative w-12 h-12 bg-muted/50 rounded-md overflow-hidden flex-shrink-0">
+          {thumbnailUrl ? (
+            <img
+              src={thumbnailUrl}
+              alt=""
+              className="w-full h-full object-cover"
+              loading="lazy"
+            />
+          ) : (
+            <div className="w-full h-full flex items-center justify-center text-xs text-muted-foreground">
+              No preview
+            </div>
+          )}
+          <div className="absolute bottom-0 right-0 bg-black/70 text-white text-[10px] px-1 rounded-tl">
+            {index + 1}
+          </div>
+        </div>
+
+        <div className="flex-1 min-w-0 space-y-2">
+          <h3 className="text-sm font-medium leading-tight line-clamp-2 break-words">
+            {label}
+          </h3>
+
+          {(dimensions ||
+            metadata.Date ||
+            metadata.Author ||
+            metadata.Publisher ||
+            metadata.Scale) && (
+            <div className="space-y-1">
+              {dimensions && (
+                <div className="text-xs text-muted-foreground font-mono">
+                  {dimensions}
+                </div>
+              )}
+              {metadata.Date && (
+                <MetadataItem
+                  icon={Calendar}
+                  label="Date"
+                  value={metadata.Date}
+                />
+              )}
+              {metadata.Author && (
+                <MetadataItem
+                  icon={User}
+                  label="Author"
+                  value={metadata.Author}
+                />
+              )}
+              {metadata.Publisher && (
+                <MetadataItem
+                  icon={Building}
+                  label="Publisher"
+                  value={metadata.Publisher}
+                />
+              )}
+              {metadata.Scale && (
+                <MetadataItem
+                  icon={Ruler}
+                  label="Scale"
+                  value={metadata.Scale}
+                />
+              )}
+            </div>
+          )}
+
+          {(isGeo || hasAnno) && (
+            <div className="flex gap-1.5">
+              {isGeo && (
+                <Badge
+                  variant="outline"
+                  className="text-[10px] py-0.5 h-auto flex items-center gap-1"
+                >
+                  <Map className="h-2.5 w-2.5" />
+                  Geo
+                </Badge>
+              )}
+              {hasAnno && (
+                <Badge
+                  variant="outline"
+                  className="text-[10px] py-0.5 h-auto flex items-center gap-1"
+                >
+                  <MessageSquare className="h-2.5 w-2.5" />
+                  Anno
+                </Badge>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </li>
+  );
+}
+
+export function CollectionSidebar({
+  manifest,
+  currentCanvas,
+  onCanvasSelect,
+}: CollectionSidebarProps) {
+  const canvases = getManifestCanvases(manifest);
+
+  const [annotationMap, setAnnotationMap] = React.useState<
+    Record<string, boolean>
+  >({});
+  const [isLoadingAnnotations, setIsLoadingAnnotations] = React.useState(true);
+
+  React.useEffect(() => {
+    let cancelled = false;
+
+    const loadAllAnnotations = async () => {
+      setIsLoadingAnnotations(true);
+      const map: Record<string, boolean> = {};
+
+      try {
+        // Use the same fetchAnnotations function as useAllAnnotations
+        const { fetchAnnotations } = await import('@/lib/annoRepo');
+
+        // Load annotations for each canvas in parallel but with limited concurrency
+        const batchSize = 5;
+        for (let i = 0; i < canvases.length; i += batchSize) {
+          if (cancelled) break;
+
+          const batch = canvases.slice(i, i + batchSize);
+          const promises = batch.map(async (canvas: any) => {
+            const canvasId = canvas?.id;
+            if (!canvasId) return;
+
+            try {
+              const { items } = await fetchAnnotations({
+                targetCanvasId: canvasId,
+                page: 0,
+              });
+              map[canvasId] = items.length > 0;
+            } catch (err) {
+              // If fetching fails, assume no annotations
+              map[canvasId] = false;
+            }
+          });
+
+          await Promise.all(promises);
+        }
+      } catch (err) {
+        console.warn('Failed to load annotations:', err);
+      }
+
+      if (!cancelled) {
+        setAnnotationMap(map);
+        setIsLoadingAnnotations(false);
+      }
+    };
+
+    if (canvases.length > 0) {
+      loadAllAnnotations();
+    } else {
+      setAnnotationMap({});
+      setIsLoadingAnnotations(false);
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [canvases]);
+
   return (
     <aside
       className="flex flex-col h-full"
@@ -179,131 +359,16 @@ export function CollectionSidebar({
 
       <ScrollArea className="flex-1">
         <ul className="p-2 space-y-1" aria-labelledby="collection-title">
-          {canvases.map((canvas: any, index: number) => {
-            const thumbnailUrl = getThumbnailUrl(canvas);
-            const isGeo = isGeoreferenced(canvas);
-            const hasAnno = hasAnnotations(canvas);
-            const isSelected = index === currentCanvas;
-            const label =
-              getLocalizedValue(canvas.label) || `Image ${index + 1}`;
-            const metadata = getCanvasMetadata(canvas);
-            const dimensions = formatDimensions(canvas);
-
-            return (
-              <li key={index}>
-                <div
-                  className={cn(
-                    'group flex items-start gap-3 p-3 rounded-lg cursor-pointer transition-all',
-                    'border border-transparent hover:border-border/50',
-                    'focus-within:outline-none focus-within:ring-2 focus-within:ring-primary/20',
-                    isSelected && 'bg-primary/10 border-primary/30 shadow-sm',
-                  )}
-                  onClick={() => onCanvasSelect(index)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault();
-                      onCanvasSelect(index);
-                    }
-                  }}
-                  tabIndex={0}
-                  role="button"
-                  aria-pressed={isSelected}
-                  aria-label={`Select ${label}${
-                    isGeo ? ', georeferenced' : ''
-                  }${hasAnno ? ', annotated' : ''}`}
-                >
-                  <div className="relative w-12 h-12 bg-muted/50 rounded-md overflow-hidden flex-shrink-0">
-                    {thumbnailUrl ? (
-                      <img
-                        src={thumbnailUrl}
-                        alt=""
-                        className="w-full h-full object-cover"
-                        loading="lazy"
-                      />
-                    ) : (
-                      <div className="w-full h-full flex items-center justify-center text-xs text-muted-foreground">
-                        No preview
-                      </div>
-                    )}
-                    <div className="absolute bottom-0 right-0 bg-black/70 text-white text-[10px] px-1 rounded-tl">
-                      {index + 1}
-                    </div>
-                  </div>
-
-                  <div className="flex-1 min-w-0 space-y-2">
-                    <h3 className="text-sm font-medium leading-tight line-clamp-2 break-words">
-                      {label}
-                    </h3>
-
-                    {(dimensions ||
-                      metadata.Date ||
-                      metadata.Author ||
-                      metadata.Publisher ||
-                      metadata.Scale) && (
-                      <div className="space-y-1">
-                        {dimensions && (
-                          <div className="text-xs text-muted-foreground font-mono">
-                            {dimensions}
-                          </div>
-                        )}
-                        {metadata.Date && (
-                          <MetadataItem
-                            icon={Calendar}
-                            label="Date"
-                            value={metadata.Date}
-                          />
-                        )}
-                        {metadata.Author && (
-                          <MetadataItem
-                            icon={User}
-                            label="Author"
-                            value={metadata.Author}
-                          />
-                        )}
-                        {metadata.Publisher && (
-                          <MetadataItem
-                            icon={Building}
-                            label="Publisher"
-                            value={metadata.Publisher}
-                          />
-                        )}
-                        {metadata.Scale && (
-                          <MetadataItem
-                            icon={Ruler}
-                            label="Scale"
-                            value={metadata.Scale}
-                          />
-                        )}
-                      </div>
-                    )}
-
-                    {(isGeo || hasAnno) && (
-                      <div className="flex gap-1.5">
-                        {isGeo && (
-                          <Badge
-                            variant="outline"
-                            className="text-[10px] py-0.5 h-auto flex items-center gap-1"
-                          >
-                            <Map className="h-2.5 w-2.5" />
-                            Geo
-                          </Badge>
-                        )}
-                        {hasAnno && (
-                          <Badge
-                            variant="outline"
-                            className="text-[10px] py-0.5 h-auto flex items-center gap-1"
-                          >
-                            <MessageSquare className="h-2.5 w-2.5" />
-                            Anno
-                          </Badge>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </li>
-            );
-          })}
+          {canvases.map((canvas: any, index: number) => (
+            <CanvasItem
+              key={index}
+              canvas={canvas}
+              index={index}
+              currentCanvas={currentCanvas}
+              onCanvasSelect={onCanvasSelect}
+              hasAnnotations={annotationMap[canvas?.id] || false}
+            />
+          ))}
         </ul>
       </ScrollArea>
     </aside>

--- a/components/CollectionStatus.tsx
+++ b/components/CollectionStatus.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { Badge } from '@/components/Badge';
+import { analyzeAnnotations, extractGeoData } from '@/lib/iiif-helpers';
+import {
+  Calendar,
+  Eye,
+  FileText,
+  Globe,
+  Image,
+  Map,
+  MessageSquare,
+  Users,
+} from 'lucide-react';
+import React from 'react';
+
+interface CollectionStatusProps {
+  manifest: any;
+  currentCanvas?: any;
+}
+
+export function CollectionStatus({
+  manifest,
+  currentCanvas,
+}: CollectionStatusProps) {
+  if (!manifest) return null;
+
+  const canvases = manifest.items || manifest.sequences?.[0]?.canvases || [];
+  const totalCanvases = canvases.length;
+
+  // Analyze current canvas
+  const canvasAnalysis = currentCanvas
+    ? analyzeAnnotations(currentCanvas)
+    : null;
+  const geoData = currentCanvas ? extractGeoData(currentCanvas) : null;
+
+  // Analyze whole collection
+  const collectionStats = canvases.reduce(
+    (acc: any, canvas: any) => {
+      const analysis = analyzeAnnotations(canvas);
+      const geo = extractGeoData(canvas);
+
+      acc.totalAnnotations += analysis.total;
+      acc.hasGeoref = acc.hasGeoref || !!geo;
+      acc.canvasesWithAnnotations += analysis.hasMeaningful ? 1 : 0;
+      acc.canvasesWithGeoref += geo ? 1 : 0;
+
+      return acc;
+    },
+    {
+      totalAnnotations: 0,
+      hasGeoref: false,
+      canvasesWithAnnotations: 0,
+      canvasesWithGeoref: 0,
+    },
+  );
+
+  const features = [
+    {
+      icon: FileText,
+      label: `${totalCanvases} item${totalCanvases !== 1 ? 's' : ''}`,
+      active: totalCanvases > 0,
+      type: 'info',
+    },
+    {
+      icon: MessageSquare,
+      label: `${collectionStats.totalAnnotations} annotation${
+        collectionStats.totalAnnotations !== 1 ? 's' : ''
+      }`,
+      active: collectionStats.totalAnnotations > 0,
+      type: collectionStats.totalAnnotations > 0 ? 'success' : 'muted',
+    },
+    {
+      icon: Map,
+      label: `${collectionStats.canvasesWithGeoref} georeferenced`,
+      active: collectionStats.hasGeoref,
+      type: collectionStats.hasGeoref ? 'success' : 'muted',
+    },
+  ];
+
+  const currentCanvasFeatures = currentCanvas
+    ? [
+        {
+          icon: Eye,
+          label: 'Current item',
+          active: true,
+          type: 'info',
+        },
+        {
+          icon: MessageSquare,
+          label: `${canvasAnalysis?.total || 0} annotation${
+            (canvasAnalysis?.total || 0) !== 1 ? 's' : ''
+          }`,
+          active: (canvasAnalysis?.total || 0) > 0,
+          type: (canvasAnalysis?.total || 0) > 0 ? 'success' : 'muted',
+        },
+        {
+          icon: Map,
+          label: geoData ? 'Mapped' : 'No map data',
+          active: !!geoData,
+          type: geoData ? 'success' : 'muted',
+        },
+      ]
+    : [];
+
+  return (
+    <div className="space-y-3">
+      {/* Collection Overview */}
+      <div>
+        <h4 className="text-sm font-medium mb-2">Collection Features</h4>
+        <div className="flex flex-wrap gap-1">
+          {features.map((feature, index) => (
+            <Badge
+              key={index}
+              variant={feature.type as any}
+              className="text-xs"
+            >
+              <feature.icon className="h-3 w-3 mr-1" />
+              {feature.label}
+            </Badge>
+          ))}
+        </div>
+      </div>
+
+      {/* Current Canvas */}
+      {currentCanvas && (
+        <div>
+          <h4 className="text-sm font-medium mb-2">Current Item</h4>
+          <div className="flex flex-wrap gap-1">
+            {currentCanvasFeatures.map((feature, index) => (
+              <Badge
+                key={index}
+                variant={feature.type as any}
+                className="text-xs"
+              >
+                <feature.icon className="h-3 w-3 mr-1" />
+                {feature.label}
+              </Badge>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Special Features Detection */}
+      {collectionStats.hasGeoref && (
+        <div className="text-xs text-muted-foreground">
+          <Globe className="h-3 w-3 inline mr-1" />
+          Map view available for georeferenced items
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/Dialog.tsx
+++ b/components/Dialog.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import * as React from 'react';
+import { cn } from '@/lib/utils';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { X } from 'lucide-react';
-import { cn } from '@/lib/utils';
+import * as React from 'react';
 
 const Dialog = DialogPrimitive.Root;
 
@@ -20,7 +20,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      'fixed inset-0 z-[10100] bg-black/90 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
       className,
     )}
     {...props}
@@ -37,7 +37,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        'fixed left-[50%] top-[50%] z-[10101] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-border bg-card text-card-foreground p-6 shadow-2xl duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
         className,
       )}
       {...props}
@@ -109,13 +109,13 @@ DialogDescription.displayName = DialogPrimitive.Description.displayName;
 
 export {
   Dialog,
-  DialogPortal,
-  DialogOverlay,
   DialogClose,
-  DialogTrigger,
   DialogContent,
-  DialogHeader,
-  DialogFooter,
-  DialogTitle,
   DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
 };

--- a/components/ImageViewer.tsx
+++ b/components/ImageViewer.tsx
@@ -15,6 +15,7 @@ interface ImageViewerProps {
   onViewerReady?: (viewer: any) => void;
   showTextspotting: boolean;
   showIconography: boolean;
+  viewMode: 'image' | 'annotation';
 }
 
 export function ImageViewer({
@@ -26,6 +27,7 @@ export function ImageViewer({
   onViewerReady,
   showTextspotting,
   showIconography,
+  viewMode,
 }: ImageViewerProps) {
   const mountRef = useRef<HTMLDivElement>(null);
   const viewerRef = useRef<any>(null);
@@ -199,7 +201,7 @@ export function ImageViewer({
             viewer.viewport.fitBounds(lastViewportRef.current, true);
             lastViewportRef.current = null;
           }
-          if (annotations.length) {
+          if (annotations.length && viewMode === 'annotation') {
             addOverlays();
             overlaysRef.current.forEach((d) => {
               const isSel = d.dataset.annotationId === selectedAnnotationId;
@@ -356,23 +358,43 @@ export function ImageViewer({
       overlaysRef.current = [];
       vpRectsRef.current = {};
     };
-  }, [manifest, currentCanvas, annotations, showTextspotting, showIconography]);
+  }, [
+    manifest,
+    currentCanvas,
+    annotations,
+    showTextspotting,
+    showIconography,
+    viewMode,
+  ]);
 
   useEffect(() => {
     if (!viewerRef.current) return;
 
-    overlaysRef.current.forEach((d) => {
-      const isSel = d.dataset.annotationId === selectedAnnotationId;
-      d.style.backgroundColor = isSel
-        ? 'rgba(255,0,0,0.3)'
-        : 'rgba(0,100,255,0.2)';
-      d.style.border = isSel
-        ? '2px solid rgba(255,0,0,0.8)'
-        : '1px solid rgba(0,100,255,0.6)';
-    });
+    if (viewMode === 'annotation') {
+      overlaysRef.current.forEach((d) => {
+        const isSel = d.dataset.annotationId === selectedAnnotationId;
+        d.style.backgroundColor = isSel
+          ? 'rgba(255,0,0,0.3)'
+          : 'rgba(0,100,255,0.2)';
+        d.style.border = isSel
+          ? '2px solid rgba(255,0,0,0.8)'
+          : '1px solid rgba(0,100,255,0.6)';
+      });
+      zoomToSelected();
+    }
+  }, [selectedAnnotationId, viewMode]);
 
-    zoomToSelected();
-  }, [selectedAnnotationId]);
+  useEffect(() => {
+    if (!viewerRef.current) return;
+
+    if (viewMode === 'annotation') {
+      return;
+    } else {
+      viewerRef.current.clearOverlays();
+      overlaysRef.current = [];
+      vpRectsRef.current = {};
+    }
+  }, [viewMode]);
 
   return (
     <div className={cn('w-full h-full relative')}>

--- a/components/ManifestErrorBoundary.tsx
+++ b/components/ManifestErrorBoundary.tsx
@@ -32,9 +32,6 @@ export class ManifestErrorBoundary extends Component<Props, State> {
       error,
       errorInfo,
     });
-
-    // Log error for debugging
-    console.error('Manifest Error Boundary caught an error:', error, errorInfo);
   }
 
   handleRetry = () => {

--- a/components/ManifestErrorBoundary.tsx
+++ b/components/ManifestErrorBoundary.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { Button } from '@/components/Button';
+import { Card } from '@/components/Card';
+import { AlertTriangle, Home, RefreshCw } from 'lucide-react';
+import React, { Component, ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+  onRetry?: () => void;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+  errorInfo: any;
+}
+
+export class ManifestErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null, errorInfo: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error, errorInfo: null };
+  }
+
+  componentDidCatch(error: Error, errorInfo: any) {
+    this.setState({
+      error,
+      errorInfo,
+    });
+
+    // Log error for debugging
+    console.error('Manifest Error Boundary caught an error:', error, errorInfo);
+  }
+
+  handleRetry = () => {
+    this.setState({ hasError: false, error: null, errorInfo: null });
+    if (this.props.onRetry) {
+      this.props.onRetry();
+    }
+  };
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback;
+      }
+
+      return (
+        <Card className="p-6 m-4">
+          <div className="text-center space-y-4">
+            <div className="flex justify-center">
+              <AlertTriangle className="h-12 w-12 text-red-500" />
+            </div>
+
+            <div>
+              <h2 className="text-lg font-semibold">Something went wrong</h2>
+              <p className="text-muted-foreground mt-1">
+                There was an error loading or displaying the collection.
+              </p>
+            </div>
+
+            {this.state.error && (
+              <details className="text-left">
+                <summary className="cursor-pointer text-sm font-medium">
+                  Error Details
+                </summary>
+                <pre className="text-xs bg-muted p-2 rounded mt-2 overflow-auto">
+                  {this.state.error.toString()}
+                  {this.state.errorInfo?.componentStack}
+                </pre>
+              </details>
+            )}
+
+            <div className="flex gap-2 justify-center">
+              <Button onClick={this.handleRetry} variant="outline" size="sm">
+                <RefreshCw className="h-4 w-4 mr-2" />
+                Try Again
+              </Button>
+              <Button onClick={() => window.location.reload()} size="sm">
+                <Home className="h-4 w-4 mr-2" />
+                Reload Page
+              </Button>
+            </div>
+          </div>
+        </Card>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/components/ManifestLoader.tsx
+++ b/components/ManifestLoader.tsx
@@ -172,12 +172,12 @@ export function ManifestLoader({
     <div className="space-y-6">
       {/* Current Collection Info */}
       {currentManifest && (
-        <Card className="p-4 bg-muted/50">
+        <Card className="p-4 bg-card border-border shadow-sm">
           <div className="flex items-center gap-2 mb-2">
-            <FileText className="h-4 w-4" />
-            <span className="font-medium">Current Collection</span>
+            <FileText className="h-4 w-4 text-primary" />
+            <span className="font-medium text-primary">Current Collection</span>
           </div>
-          <p className="text-sm text-muted-foreground">
+          <p className="text-sm text-card-foreground">
             {typeof currentManifest.label === 'string'
               ? currentManifest.label
               : currentManifest.label?.en?.[0] || 'Untitled Collection'}
@@ -244,14 +244,14 @@ export function ManifestLoader({
 
       {/* Validation Results */}
       {validationResult && (
-        <Card className="p-4">
+        <Card className="p-4 bg-card border-border shadow-sm">
           <div className="flex items-center gap-2 mb-2">
             {validationResult.isValid ? (
               <CheckCircle className="h-4 w-4 text-green-600" />
             ) : (
               <XCircle className="h-4 w-4 text-red-600" />
             )}
-            <span className="font-medium">
+            <span className="font-medium text-card-foreground">
               {validationResult.isValid
                 ? 'Valid Collection'
                 : 'Invalid Collection'}
@@ -401,11 +401,11 @@ export function ManifestLoader({
       </div>
 
       {/* Help Section */}
-      <div className="space-y-2">
-        <Label className="text-sm font-medium">
+      <div className="space-y-2 p-4 bg-card border border-border rounded-lg shadow-sm">
+        <Label className="text-sm font-medium text-primary">
           IIIF Image & Presentation Loader
         </Label>
-        <div className="text-xs text-muted-foreground space-y-1">
+        <div className="text-xs text-card-foreground space-y-1">
           <p>
             <strong>Supports:</strong> IIIF Presentation API v2 & v3 with image
             content only
@@ -419,7 +419,7 @@ export function ManifestLoader({
             manifests
           </p>
         </div>
-        <div className="text-xs text-muted-foreground space-y-1 mt-3">
+        <div className="text-xs text-muted-foreground space-y-1 mt-3 pt-3 border-t border-border">
           <p>• Use "From Web" if you have a link to an online collection</p>
           <p>
             • Use "Upload File" if you have a collection file on your computer

--- a/components/ManifestLoader.tsx
+++ b/components/ManifestLoader.tsx
@@ -402,8 +402,24 @@ export function ManifestLoader({
 
       {/* Help Section */}
       <div className="space-y-2">
-        <Label className="text-sm font-medium">Need Help?</Label>
+        <Label className="text-sm font-medium">
+          IIIF Image & Presentation Loader
+        </Label>
         <div className="text-xs text-muted-foreground space-y-1">
+          <p>
+            <strong>Supports:</strong> IIIF Presentation API v2 & v3 with image
+            content only
+          </p>
+          <p>
+            <strong>Compatible:</strong> Image manifests, single canvases,
+            digital books, manuscripts
+          </p>
+          <p>
+            <strong>Not supported:</strong> Audio, video, or time-based media
+            manifests
+          </p>
+        </div>
+        <div className="text-xs text-muted-foreground space-y-1 mt-3">
           <p>• Use "From Web" if you have a link to an online collection</p>
           <p>
             • Use "Upload File" if you have a collection file on your computer
@@ -416,7 +432,7 @@ export function ManifestLoader({
 
         <details className="mt-3">
           <summary className="text-xs font-medium cursor-pointer text-muted-foreground hover:text-foreground">
-            Show example collections
+            Show example image collections
           </summary>
           <div className="space-y-2 mt-2">
             <Button

--- a/components/ManifestLoader.tsx
+++ b/components/ManifestLoader.tsx
@@ -103,9 +103,7 @@ export function ManifestLoader({
       try {
         const { isV2, isV3 } = validateIIIFManifest(data);
         toast({
-          title: `Default IIIF ${
-            isV3 ? 'v3' : isV2 ? 'v2' : ''
-          } manifest loaded`,
+          title: `Default collection loaded`,
           description:
             data.label?.en?.[0] ||
             data.label?.none?.[0] ||
@@ -114,7 +112,7 @@ export function ManifestLoader({
       } catch (validationError) {
         console.warn('Default manifest validation warning:', validationError);
         toast({
-          title: 'Default manifest loaded (with warnings)',
+          title: 'Default collection loaded (with warnings)',
           description:
             data.label?.en?.[0] ||
             data.label?.none?.[0] ||
@@ -126,7 +124,7 @@ export function ManifestLoader({
       onClose();
     } catch (err: any) {
       const msg = err?.message || 'Unknown error';
-      toast({ title: 'Failed to load default manifest', description: msg });
+      toast({ title: 'Could not load default collection', description: msg });
     } finally {
       setIsLoading(false);
     }
@@ -148,19 +146,17 @@ export function ManifestLoader({
 
       onManifestLoad(data);
       toast({
-        title: `IIIF ${
-          isV3 ? 'v3' : isV2 ? 'v2' : ''
-        } manifest loaded from URL`,
+        title: `Collection loaded successfully`,
         description:
           data.label?.en?.[0] ||
           data.label?.none?.[0] ||
           data.label ||
-          'Remote manifest',
+          'Remote collection',
       });
       onClose();
     } catch (err: any) {
       const msg = err?.message || 'Unknown error';
-      toast({ title: 'Failed to load manifest from URL', description: msg });
+      toast({ title: 'Could not load collection', description: msg });
     } finally {
       setIsLoading(false);
     }
@@ -179,19 +175,17 @@ export function ManifestLoader({
 
       onManifestLoad(data);
       toast({
-        title: `IIIF ${
-          isV3 ? 'v3' : isV2 ? 'v2' : ''
-        } manifest loaded from JSON`,
+        title: `Collection loaded successfully`,
         description:
           data.label?.en?.[0] ||
           data.label?.none?.[0] ||
           data.label ||
-          'Custom manifest',
+          'Custom collection',
       });
       onClose();
     } catch (err: any) {
-      const msg = err?.message || 'Invalid JSON or manifest format';
-      toast({ title: 'Failed to parse manifest', description: msg });
+      const msg = err?.message || 'Invalid data format';
+      toast({ title: 'Could not parse collection data', description: msg });
     } finally {
       setIsLoading(false);
     }
@@ -222,17 +216,17 @@ export function ManifestLoader({
 
   return (
     <div className="space-y-6">
-      {/* Current Manifest Info */}
+      {/* Current Collection Info */}
       {currentManifest && (
         <Card className="p-4 bg-muted/50">
           <div className="flex items-center gap-2 mb-2">
             <FileText className="h-4 w-4" />
-            <span className="font-medium">Current Manifest</span>
+            <span className="font-medium">Current Collection</span>
           </div>
           <p className="text-sm text-muted-foreground">
             {typeof currentManifest.label === 'string'
               ? currentManifest.label
-              : currentManifest.label?.en?.[0] || 'Untitled Manifest'}
+              : currentManifest.label?.en?.[0] || 'Untitled Collection'}
           </p>
           <p className="text-xs text-muted-foreground mt-1">
             {currentManifest.items?.length || 0} items
@@ -240,7 +234,7 @@ export function ManifestLoader({
         </Card>
       )}
 
-      {/* Default Manifest */}
+      {/* Default Collection */}
       <div>
         <Button
           onClick={loadDefaultManifest}
@@ -253,7 +247,7 @@ export function ManifestLoader({
           ) : (
             <FileText className="h-4 w-4 mr-2" />
           )}
-          Load Default Manifest (Necessary Reunions)
+          Load Default Collection (Necessary Reunions)
         </Button>
       </div>
 
@@ -268,7 +262,7 @@ export function ManifestLoader({
           onClick={() => setActiveTab('url')}
         >
           <Link className="h-4 w-4 mr-1 inline" />
-          From URL
+          From Web
         </button>
         <button
           className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
@@ -290,7 +284,7 @@ export function ManifestLoader({
           onClick={() => setActiveTab('json')}
         >
           <FileText className="h-4 w-4 mr-1 inline" />
-          Paste JSON
+          Custom Data
         </button>
       </div>
 
@@ -299,7 +293,7 @@ export function ManifestLoader({
         {activeTab === 'url' && (
           <div className="space-y-4">
             <div>
-              <Label htmlFor="manifest-url">Manifest URL</Label>
+              <Label htmlFor="manifest-url">Collection Web Address</Label>
               <Input
                 id="manifest-url"
                 type="url"
@@ -309,7 +303,7 @@ export function ManifestLoader({
                 className="mt-1"
               />
               <p className="text-xs text-muted-foreground mt-1">
-                Enter the URL of a IIIF manifest.json file
+                Enter the web address of a digital collection
               </p>
             </div>
             <Button
@@ -322,7 +316,7 @@ export function ManifestLoader({
               ) : (
                 <ExternalLink className="h-4 w-4 mr-2" />
               )}
-              Load from URL
+              Load Collection
             </Button>
           </div>
         )}
@@ -330,7 +324,7 @@ export function ManifestLoader({
         {activeTab === 'file' && (
           <div className="space-y-4">
             <div>
-              <Label htmlFor="manifest-file">Upload Manifest File</Label>
+              <Label htmlFor="manifest-file">Upload Collection File</Label>
               <Input
                 id="manifest-file"
                 type="file"
@@ -339,7 +333,7 @@ export function ManifestLoader({
                 className="mt-1"
               />
               <p className="text-xs text-muted-foreground mt-1">
-                Select a IIIF manifest.json file from your computer
+                Select a collection file (.json) from your computer
               </p>
             </div>
           </div>
@@ -348,16 +342,16 @@ export function ManifestLoader({
         {activeTab === 'json' && (
           <div className="space-y-4">
             <div>
-              <Label htmlFor="manifest-json">Manifest JSON</Label>
+              <Label htmlFor="manifest-json">Collection Data</Label>
               <Textarea
                 id="manifest-json"
-                placeholder="Paste your IIIF manifest JSON here..."
+                placeholder="Paste your collection data here..."
                 value={manifestJson}
                 onChange={(e) => setManifestJson(e.target.value)}
                 className="mt-1 min-h-[200px] font-mono text-sm"
               />
               <p className="text-xs text-muted-foreground mt-1">
-                Paste the contents of a IIIF manifest.json file
+                Paste the contents of a collection file
               </p>
             </div>
             <Button
@@ -370,101 +364,75 @@ export function ManifestLoader({
               ) : (
                 <FileText className="h-4 w-4 mr-2" />
               )}
-              Load from JSON
+              Load Collection
             </Button>
           </div>
         )}
       </div>
 
-      {/* Sample Manifests */}
+      {/* Help Section */}
       <div className="space-y-2">
-        <Label className="text-sm font-medium">Sample Manifests</Label>
-        <div className="space-y-2">
-          <Button
-            variant="ghost"
-            size="sm"
-            className="w-full justify-start text-xs h-8"
-            onClick={() => {
-              setManifestUrl(
-                'https://iiif.io/api/cookbook/recipe/0001-mvm-image/manifest.json',
-              );
-              setActiveTab('url');
-            }}
-          >
-            <ExternalLink className="h-3 w-3 mr-2" />
-            IIIF Cookbook - Simple Image (v3)
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="w-full justify-start text-xs h-8"
-            onClick={() => {
-              setManifestUrl(
-                'https://iiif.io/api/cookbook/recipe/0005-image-service/manifest.json',
-              );
-              setActiveTab('url');
-            }}
-          >
-            <ExternalLink className="h-3 w-3 mr-2" />
-            IIIF Cookbook - Image Service (v3)
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="w-full justify-start text-xs h-8"
-            onClick={() => {
-              setManifestUrl(
-                'https://iiif.io/api/cookbook/recipe/0009-book-1/manifest.json',
-              );
-              setActiveTab('url');
-            }}
-          >
-            <ExternalLink className="h-3 w-3 mr-2" />
-            IIIF Cookbook - Multi-page Book (v3)
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="w-full justify-start text-xs h-8"
-            onClick={() => {
-              setManifestUrl(
-                'https://uvaerfgoed.nl/viewer/api/v1/records/11245_3_2556/manifest/',
-              );
-              setActiveTab('url');
-            }}
-          >
-            <ExternalLink className="h-3 w-3 mr-2" />
-            UVA Heritage - Dutch Map (v2)
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="w-full justify-start text-xs h-8"
-            onClick={() => {
-              setManifestUrl(
-                'https://dms-data.stanford.edu/data/manifests/Walters/qm670kv1873/manifest.json',
-              );
-              setActiveTab('url');
-            }}
-          >
-            <ExternalLink className="h-3 w-3 mr-2" />
-            Stanford Walters - Manuscript (v2)
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="w-full justify-start text-xs h-8"
-            onClick={() => {
-              setManifestUrl(
-                'https://wellcomelibrary.org/iiif/b18035723/manifest',
-              );
-              setActiveTab('url');
-            }}
-          >
-            <ExternalLink className="h-3 w-3 mr-2" />
-            Wellcome Library - Book (v2)
-          </Button>
+        <Label className="text-sm font-medium">Need Help?</Label>
+        <div className="text-xs text-muted-foreground space-y-1">
+          <p>• Use "From Web" if you have a link to an online collection</p>
+          <p>
+            • Use "Upload File" if you have a collection file on your computer
+          </p>
+          <p>
+            • Use "Custom Data" if you want to paste collection information
+            directly
+          </p>
         </div>
+
+        <details className="mt-3">
+          <summary className="text-xs font-medium cursor-pointer text-muted-foreground hover:text-foreground">
+            Show example collections
+          </summary>
+          <div className="space-y-2 mt-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="w-full justify-start text-xs h-8"
+              onClick={() => {
+                setManifestUrl(
+                  'https://iiif.io/api/cookbook/recipe/0009-book-1/manifest.json',
+                );
+                setActiveTab('url');
+              }}
+            >
+              <ExternalLink className="h-3 w-3 mr-2" />
+              IIIF Cookbook - Sample Book
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="w-full justify-start text-xs h-8"
+              onClick={() => {
+                setManifestUrl(
+                  'https://uvaerfgoed.nl/viewer/api/v1/records/11245_3_2556/manifest/',
+                );
+                setActiveTab('url');
+              }}
+            >
+              <ExternalLink className="h-3 w-3 mr-2" />
+              UVA Heritage - Historical Map
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="w-full justify-start text-xs h-8"
+              onClick={() => {
+                setManifestUrl(
+                  'https://wellcomelibrary.org/iiif/b18035723/manifest',
+                );
+                setActiveTab('url');
+              }}
+            >
+              <ExternalLink className="h-3 w-3 mr-2" />
+              Wellcome Library - Historical Book
+            </Button>
+          </div>
+        </details>
       </div>
     </div>
   );

--- a/components/ManifestLoader.tsx
+++ b/components/ManifestLoader.tsx
@@ -6,6 +6,7 @@ import { Input } from '@/components/Input';
 import { Label } from '@/components/Label';
 import { Textarea } from '@/components/Textarea';
 import { useToast } from '@/hooks/use-toast';
+import { getAllLocalizedValues, getLocalizedValue } from '@/lib/iiif-helpers';
 import {
   getValidationSummary,
   validateManifest,
@@ -76,9 +77,7 @@ export function ManifestLoader({
         toast({
           title: 'Default manifest loaded (with warnings)',
           description:
-            data.label?.en?.[0] ||
-            data.label?.none?.[0] ||
-            'Necessary Reunions Collection',
+            getLocalizedValue(data.label) || 'Necessary Reunions Collection',
         });
       }
 
@@ -177,11 +176,39 @@ export function ManifestLoader({
             <FileText className="h-4 w-4 text-primary" />
             <span className="font-medium text-primary">Current Manifest</span>
           </div>
-          <p className="text-sm text-card-foreground">
-            {typeof currentManifest.label === 'string'
-              ? currentManifest.label
-              : currentManifest.label?.en?.[0] || 'Untitled Manifest'}
-          </p>
+          <div className="space-y-2">
+            {(() => {
+              if (typeof currentManifest.label === 'string') {
+                return (
+                  <p className="text-sm text-card-foreground">
+                    {currentManifest.label}
+                  </p>
+                );
+              }
+
+              const allLabels = getAllLocalizedValues(currentManifest.label);
+              if (allLabels && allLabels.length > 0) {
+                return (
+                  <div className="space-y-1">
+                    {allLabels.map(({ language, value }, index) => (
+                      <div key={index} className="text-sm">
+                        <span className="text-xs text-muted-foreground font-medium uppercase tracking-wide">
+                          {language}:
+                        </span>
+                        <p className="text-card-foreground mt-0.5">{value}</p>
+                      </div>
+                    ))}
+                  </div>
+                );
+              }
+
+              return (
+                <p className="text-sm text-card-foreground">
+                  Untitled Manifest
+                </p>
+              );
+            })()}
+          </div>
           <p className="text-xs text-muted-foreground mt-1">
             {currentManifest.items?.length || 0} items
           </p>

--- a/components/ManifestLoader.tsx
+++ b/components/ManifestLoader.tsx
@@ -68,13 +68,13 @@ export function ManifestLoader({
       try {
         const validation = validateIIIFManifest(data);
         toast({
-          title: `Default collection loaded`,
+          title: `Default manifest loaded`,
           description: getValidationSummary(validation),
         });
       } catch (validationError) {
         console.warn('Default manifest validation warning:', validationError);
         toast({
-          title: 'Default collection loaded (with warnings)',
+          title: 'Default manifest loaded (with warnings)',
           description:
             data.label?.en?.[0] ||
             data.label?.none?.[0] ||
@@ -86,7 +86,7 @@ export function ManifestLoader({
       onClose();
     } catch (err: any) {
       const msg = err?.message || 'Unknown error';
-      toast({ title: 'Could not load default collection', description: msg });
+      toast({ title: 'Could not load default manifest', description: msg });
     } finally {
       setIsLoading(false);
     }
@@ -108,13 +108,13 @@ export function ManifestLoader({
 
       onManifestLoad(data);
       toast({
-        title: `Collection loaded successfully`,
+        title: `Manifest loaded successfully`,
         description: getValidationSummary(validation),
       });
       onClose();
     } catch (err: any) {
       const msg = err?.message || 'Unknown error';
-      toast({ title: 'Could not load collection', description: msg });
+      toast({ title: 'Could not load manifest', description: msg });
     } finally {
       setIsLoading(false);
     }
@@ -133,13 +133,13 @@ export function ManifestLoader({
 
       onManifestLoad(data);
       toast({
-        title: `Collection loaded successfully`,
+        title: `Manifest loaded successfully`,
         description: getValidationSummary(validation),
       });
       onClose();
     } catch (err: any) {
       const msg = err?.message || 'Invalid data format';
-      toast({ title: 'Could not parse collection data', description: msg });
+      toast({ title: 'Could not parse manifest data', description: msg });
     } finally {
       setIsLoading(false);
     }
@@ -170,17 +170,17 @@ export function ManifestLoader({
 
   return (
     <div className="space-y-6">
-      {/* Current Collection Info */}
+      {/* Current Manifest Info */}
       {currentManifest && (
         <Card className="p-4 bg-card border-border shadow-sm">
           <div className="flex items-center gap-2 mb-2">
             <FileText className="h-4 w-4 text-primary" />
-            <span className="font-medium text-primary">Current Collection</span>
+            <span className="font-medium text-primary">Current Manifest</span>
           </div>
           <p className="text-sm text-card-foreground">
             {typeof currentManifest.label === 'string'
               ? currentManifest.label
-              : currentManifest.label?.en?.[0] || 'Untitled Collection'}
+              : currentManifest.label?.en?.[0] || 'Untitled Manifest'}
           </p>
           <p className="text-xs text-muted-foreground mt-1">
             {currentManifest.items?.length || 0} items
@@ -188,7 +188,7 @@ export function ManifestLoader({
         </Card>
       )}
 
-      {/* Default Collection */}
+      {/* Default Manifest */}
       <div>
         <Button
           onClick={loadDefaultManifest}
@@ -201,7 +201,7 @@ export function ManifestLoader({
           ) : (
             <FileText className="h-4 w-4 mr-2" />
           )}
-          Load Default Collection (Necessary Reunions)
+          Load Default Manifest (Necessary Reunions)
         </Button>
       </div>
 
@@ -252,9 +252,7 @@ export function ManifestLoader({
               <XCircle className="h-4 w-4 text-red-600" />
             )}
             <span className="font-medium text-card-foreground">
-              {validationResult.isValid
-                ? 'Valid Collection'
-                : 'Invalid Collection'}
+              {validationResult.isValid ? 'Valid Manifest' : 'Invalid Manifest'}
             </span>
           </div>
 
@@ -293,7 +291,7 @@ export function ManifestLoader({
         {activeTab === 'url' && (
           <div className="space-y-4">
             <div>
-              <Label htmlFor="manifest-url">Collection Web Address</Label>
+              <Label htmlFor="manifest-url">Manifest Web Address</Label>
               <Input
                 id="manifest-url"
                 type="url"
@@ -303,7 +301,7 @@ export function ManifestLoader({
                 className="mt-1"
               />
               <p className="text-xs text-muted-foreground mt-1">
-                Enter the web address of a digital collection
+                Enter the web address of a digital manifest
               </p>
             </div>
             <Button
@@ -316,7 +314,7 @@ export function ManifestLoader({
               ) : (
                 <ExternalLink className="h-4 w-4 mr-2" />
               )}
-              Load Collection
+              Load Manifest
             </Button>
           </div>
         )}
@@ -324,7 +322,7 @@ export function ManifestLoader({
         {activeTab === 'file' && (
           <div className="space-y-4">
             <div>
-              <Label htmlFor="manifest-file">Upload Collection File</Label>
+              <Label htmlFor="manifest-file">Upload Manifest File</Label>
               <Input
                 id="manifest-file"
                 type="file"
@@ -333,7 +331,7 @@ export function ManifestLoader({
                 className="mt-1"
               />
               <p className="text-xs text-muted-foreground mt-1">
-                Select a collection file (.json) from your computer
+                Select a manifest file (.json) from your computer
               </p>
             </div>
           </div>
@@ -342,10 +340,10 @@ export function ManifestLoader({
         {activeTab === 'json' && (
           <div className="space-y-4">
             <div>
-              <Label htmlFor="manifest-json">Collection Data</Label>
+              <Label htmlFor="manifest-json">Manifest Data</Label>
               <Textarea
                 id="manifest-json"
-                placeholder="Paste your collection data here..."
+                placeholder="Paste your manifest data here..."
                 value={manifestJson}
                 onChange={(e) => {
                   setManifestJson(e.target.value);
@@ -377,7 +375,7 @@ export function ManifestLoader({
                 className="mt-1 min-h-[200px] font-mono text-sm"
               />
               <p className="text-xs text-muted-foreground mt-1">
-                Paste the contents of a collection file
+                Paste the contents of a manifest file
               </p>
             </div>
             <Button
@@ -394,7 +392,7 @@ export function ManifestLoader({
               ) : (
                 <FileText className="h-4 w-4 mr-2" />
               )}
-              Load Collection
+              Load Manifest
             </Button>
           </div>
         )}
@@ -420,19 +418,19 @@ export function ManifestLoader({
           </p>
         </div>
         <div className="text-xs text-muted-foreground space-y-1 mt-3 pt-3 border-t border-border">
-          <p>• Use "From Web" if you have a link to an online collection</p>
+          <p>• Use "From Web" if you have a link to an online manifest</p>
           <p>
-            • Use "Upload File" if you have a collection file on your computer
+            • Use "Upload File" if you have a manifest file on your computer
           </p>
           <p>
-            • Use "Custom Data" if you want to paste collection information
+            • Use "Custom Data" if you want to paste manifest information
             directly
           </p>
         </div>
 
         <details className="mt-3">
           <summary className="text-xs font-medium cursor-pointer text-muted-foreground hover:text-foreground">
-            Show example image collections
+            Show example image manifests
           </summary>
           <div className="space-y-2 mt-2">
             <Button

--- a/components/ManifestLoader.tsx
+++ b/components/ManifestLoader.tsx
@@ -1,14 +1,14 @@
 'use client';
 
-import React, { useState, useCallback } from 'react';
 import { Button } from '@/components/Button';
+import { Card } from '@/components/Card';
 import { Input } from '@/components/Input';
 import { Label } from '@/components/Label';
 import { Textarea } from '@/components/Textarea';
-import { Card } from '@/components/Card';
-import { Upload, Link, FileText, Loader2, ExternalLink } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import type { Manifest } from '@/lib/types';
+import { ExternalLink, FileText, Link, Loader2, Upload } from 'lucide-react';
+import React, { useCallback, useState } from 'react';
 
 interface ManifestLoaderProps {
   currentManifest?: Manifest | null;
@@ -27,25 +27,102 @@ export function ManifestLoader({
   const [activeTab, setActiveTab] = useState<'url' | 'file' | 'json'>('url');
   const { toast } = useToast();
 
+  const validateIIIFManifest = useCallback((data: any) => {
+    const context = data['@context'];
+    const isV2 =
+      context &&
+      (Array.isArray(context)
+        ? context.some(
+            (c: string) =>
+              c.includes('api/presentation/2') ||
+              c.includes('shared-canvas.org'),
+          )
+        : context.includes('api/presentation/2') ||
+          context.includes('shared-canvas.org'));
+    const isV3 =
+      context &&
+      (Array.isArray(context)
+        ? context.some((c: string) => c.includes('api/presentation/3'))
+        : context.includes('api/presentation/3'));
+
+    const hasV2Structure = data['@type'] === 'sc:Manifest' && data.sequences;
+
+    if (isV3 && data.type !== 'Manifest') {
+      throw new Error('Invalid IIIF v3 manifest: type must be "Manifest"');
+    }
+
+    if ((isV2 || hasV2Structure) && data['@type'] !== 'sc:Manifest') {
+      throw new Error('Invalid IIIF v2 manifest: @type must be "sc:Manifest"');
+    }
+
+    if (!isV2 && !isV3 && !hasV2Structure && data.type !== 'Manifest') {
+      throw new Error('Invalid IIIF manifest: missing valid context or type');
+    }
+
+    const hasV3Content =
+      isV3 && data.items && Array.isArray(data.items) && data.items.length > 0;
+    const hasV2Content =
+      (isV2 || hasV2Structure) &&
+      data.sequences &&
+      Array.isArray(data.sequences) &&
+      data.sequences.length > 0 &&
+      data.sequences[0].canvases &&
+      Array.isArray(data.sequences[0].canvases) &&
+      data.sequences[0].canvases.length > 0;
+
+    if (!hasV3Content && !hasV2Content) {
+      throw new Error(
+        'Manifest contains no viewable content (no canvases found)',
+      );
+    }
+
+    if (!data.id && !data['@id']) {
+      throw new Error('Manifest missing required id property');
+    }
+
+    if (!data.label) {
+      throw new Error('Manifest missing required label property');
+    }
+
+    return { isV2, isV3 };
+  }, []);
+
   const loadDefaultManifest = useCallback(async () => {
     setIsLoading(true);
     try {
-      // Try local API first
       let res = await fetch('/api/manifest');
       if (!res.ok) {
-        // Fallback to static manifest
         res = await fetch(
           'https://globalise-huygens.github.io/necessary-reunions/manifest.json',
         );
       }
-      if (!res.ok) throw new Error(`Status ${res.status}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`);
 
       const data = await res.json();
+
+      try {
+        const { isV2, isV3 } = validateIIIFManifest(data);
+        toast({
+          title: `Default IIIF ${
+            isV3 ? 'v3' : isV2 ? 'v2' : ''
+          } manifest loaded`,
+          description:
+            data.label?.en?.[0] ||
+            data.label?.none?.[0] ||
+            'Necessary Reunions Collection',
+        });
+      } catch (validationError) {
+        console.warn('Default manifest validation warning:', validationError);
+        toast({
+          title: 'Default manifest loaded (with warnings)',
+          description:
+            data.label?.en?.[0] ||
+            data.label?.none?.[0] ||
+            'Necessary Reunions Collection',
+        });
+      }
+
       onManifestLoad(data);
-      toast({
-        title: 'Default manifest loaded',
-        description: data.label?.en?.[0] || 'Necessary Reunions Collection',
-      });
       onClose();
     } catch (err: any) {
       const msg = err?.message || 'Unknown error';
@@ -53,7 +130,7 @@ export function ManifestLoader({
     } finally {
       setIsLoading(false);
     }
-  }, [onManifestLoad, onClose, toast]);
+  }, [onManifestLoad, onClose, toast, validateIIIFManifest]);
 
   const loadManifestFromUrl = useCallback(async () => {
     if (!manifestUrl.trim()) {
@@ -64,31 +141,21 @@ export function ManifestLoader({
     setIsLoading(true);
     try {
       const res = await fetch(manifestUrl);
-      if (!res.ok) throw new Error(`Status ${res.status}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`);
 
       const data = await res.json();
-
-      // Basic IIIF manifest validation for both v2 and v3
-      const isV2 =
-        data['@context'] && data['@context'].includes('api/presentation/2');
-      const isV3 =
-        data['@context'] && data['@context'].includes('api/presentation/3');
-
-      if (!isV2 && !isV3 && !data.type) {
-        throw new Error('Invalid IIIF manifest format');
-      }
-
-      // Check if manifest has content (canvases)
-      const hasContent =
-        (isV3 && data.items) || (isV2 && data.sequences?.[0]?.canvases);
-      if (!hasContent) {
-        throw new Error('Manifest contains no viewable content');
-      }
+      const { isV2, isV3 } = validateIIIFManifest(data);
 
       onManifestLoad(data);
       toast({
-        title: 'Manifest loaded from URL',
-        description: data.label?.en?.[0] || data.label || 'Remote manifest',
+        title: `IIIF ${
+          isV3 ? 'v3' : isV2 ? 'v2' : ''
+        } manifest loaded from URL`,
+        description:
+          data.label?.en?.[0] ||
+          data.label?.none?.[0] ||
+          data.label ||
+          'Remote manifest',
       });
       onClose();
     } catch (err: any) {
@@ -97,7 +164,7 @@ export function ManifestLoader({
     } finally {
       setIsLoading(false);
     }
-  }, [manifestUrl, onManifestLoad, onClose, toast]);
+  }, [manifestUrl, onManifestLoad, onClose, toast, validateIIIFManifest]);
 
   const loadManifestFromJson = useCallback(async () => {
     if (!manifestJson.trim()) {
@@ -108,28 +175,18 @@ export function ManifestLoader({
     setIsLoading(true);
     try {
       const data = JSON.parse(manifestJson);
-
-      // Basic IIIF manifest validation for both v2 and v3
-      const isV2 =
-        data['@context'] && data['@context'].includes('api/presentation/2');
-      const isV3 =
-        data['@context'] && data['@context'].includes('api/presentation/3');
-
-      if (!isV2 && !isV3 && !data.type) {
-        throw new Error('Invalid IIIF manifest format');
-      }
-
-      // Check if manifest has content (canvases)
-      const hasContent =
-        (isV3 && data.items) || (isV2 && data.sequences?.[0]?.canvases);
-      if (!hasContent) {
-        throw new Error('Manifest contains no viewable content');
-      }
+      const { isV2, isV3 } = validateIIIFManifest(data);
 
       onManifestLoad(data);
       toast({
-        title: 'Manifest loaded from JSON',
-        description: data.label?.en?.[0] || data.label || 'Custom manifest',
+        title: `IIIF ${
+          isV3 ? 'v3' : isV2 ? 'v2' : ''
+        } manifest loaded from JSON`,
+        description:
+          data.label?.en?.[0] ||
+          data.label?.none?.[0] ||
+          data.label ||
+          'Custom manifest',
       });
       onClose();
     } catch (err: any) {
@@ -138,7 +195,7 @@ export function ManifestLoader({
     } finally {
       setIsLoading(false);
     }
-  }, [manifestJson, onManifestLoad, onClose, toast]);
+  }, [manifestJson, onManifestLoad, onClose, toast, validateIIIFManifest]);
 
   const handleFileUpload = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -335,7 +392,7 @@ export function ManifestLoader({
             }}
           >
             <ExternalLink className="h-3 w-3 mr-2" />
-            IIIF Cookbook - Simple Image
+            IIIF Cookbook - Simple Image (v3)
           </Button>
           <Button
             variant="ghost"
@@ -349,7 +406,21 @@ export function ManifestLoader({
             }}
           >
             <ExternalLink className="h-3 w-3 mr-2" />
-            IIIF Cookbook - Image Service
+            IIIF Cookbook - Image Service (v3)
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="w-full justify-start text-xs h-8"
+            onClick={() => {
+              setManifestUrl(
+                'https://iiif.io/api/cookbook/recipe/0009-book-1/manifest.json',
+              );
+              setActiveTab('url');
+            }}
+          >
+            <ExternalLink className="h-3 w-3 mr-2" />
+            IIIF Cookbook - Multi-page Book (v3)
           </Button>
           <Button
             variant="ghost"
@@ -363,7 +434,35 @@ export function ManifestLoader({
             }}
           >
             <ExternalLink className="h-3 w-3 mr-2" />
-            UVA Heritage - Dutch Map (IIIF v2)
+            UVA Heritage - Dutch Map (v2)
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="w-full justify-start text-xs h-8"
+            onClick={() => {
+              setManifestUrl(
+                'https://dms-data.stanford.edu/data/manifests/Walters/qm670kv1873/manifest.json',
+              );
+              setActiveTab('url');
+            }}
+          >
+            <ExternalLink className="h-3 w-3 mr-2" />
+            Stanford Walters - Manuscript (v2)
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="w-full justify-start text-xs h-8"
+            onClick={() => {
+              setManifestUrl(
+                'https://wellcomelibrary.org/iiif/b18035723/manifest',
+              );
+              setActiveTab('url');
+            }}
+          >
+            <ExternalLink className="h-3 w-3 mr-2" />
+            Wellcome Library - Book (v2)
           </Button>
         </div>
       </div>

--- a/components/ManifestLoading.tsx
+++ b/components/ManifestLoading.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { Card } from '@/components/Card';
+import { LoadingSpinner } from '@/components/LoadingSpinner';
+import { Progress } from '@/components/Progress';
+import { CheckCircle, Circle, Loader2 } from 'lucide-react';
+import React from 'react';
+
+interface LoadingStep {
+  id: string;
+  label: string;
+  status: 'pending' | 'loading' | 'complete' | 'error';
+  description?: string;
+}
+
+interface ManifestLoadingProps {
+  steps: LoadingStep[];
+  currentStep?: string;
+  progress?: number;
+}
+
+export function ManifestLoading({
+  steps,
+  currentStep,
+  progress,
+}: ManifestLoadingProps) {
+  const completedSteps = steps.filter(
+    (step) => step.status === 'complete',
+  ).length;
+  const progressPercent = progress ?? (completedSteps / steps.length) * 100;
+
+  return (
+    <Card className="p-6">
+      <div className="space-y-4">
+        <div className="text-center">
+          <h3 className="font-medium">Loading Collection</h3>
+          <p className="text-sm text-muted-foreground">
+            Please wait while we prepare your collection...
+          </p>
+        </div>
+
+        <Progress value={progressPercent} className="w-full" />
+
+        <div className="space-y-3">
+          {steps.map((step) => (
+            <div key={step.id} className="flex items-center gap-3">
+              <div className="flex-shrink-0">
+                {step.status === 'complete' && (
+                  <CheckCircle className="h-5 w-5 text-green-600" />
+                )}
+                {step.status === 'loading' && (
+                  <Loader2 className="h-5 w-5 animate-spin text-blue-600" />
+                )}
+                {step.status === 'pending' && (
+                  <Circle className="h-5 w-5 text-muted-foreground" />
+                )}
+                {step.status === 'error' && (
+                  <Circle className="h-5 w-5 text-red-600" />
+                )}
+              </div>
+
+              <div className="flex-1 min-w-0">
+                <p
+                  className={`text-sm font-medium ${
+                    step.status === 'complete'
+                      ? 'text-green-600'
+                      : step.status === 'loading'
+                      ? 'text-blue-600'
+                      : step.status === 'error'
+                      ? 'text-red-600'
+                      : 'text-muted-foreground'
+                  }`}
+                >
+                  {step.label}
+                </p>
+                {step.description && (
+                  <p className="text-xs text-muted-foreground">
+                    {step.description}
+                  </p>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+export const defaultLoadingSteps: LoadingStep[] = [
+  {
+    id: 'fetch',
+    label: 'Fetching collection data',
+    status: 'pending',
+    description: 'Downloading collection information...',
+  },
+  {
+    id: 'validate',
+    label: 'Validating format',
+    status: 'pending',
+    description: 'Checking collection structure...',
+  },
+  {
+    id: 'normalize',
+    label: 'Processing content',
+    status: 'pending',
+    description: 'Normalizing collection format...',
+  },
+  {
+    id: 'annotations',
+    label: 'Loading annotations',
+    status: 'pending',
+    description: 'Merging local annotations...',
+  },
+  {
+    id: 'geo',
+    label: 'Checking map data',
+    status: 'pending',
+    description: 'Looking for georeferencing information...',
+  },
+  {
+    id: 'complete',
+    label: 'Ready to view',
+    status: 'pending',
+    description: 'Collection is ready for exploration',
+  },
+];

--- a/components/ManifestViewer.tsx
+++ b/components/ManifestViewer.tsx
@@ -95,6 +95,11 @@ export function ManifestViewer({
   };
 
   useEffect(() => {
+    if (annotations.length > 0) {
+      console.log('Motivations found:', [
+        ...new Set(annotations.map((a) => a.motivation)),
+      ]);
+    }
     setLocalAnnotations(annotations);
   }, [annotations]);
 
@@ -225,14 +230,13 @@ export function ManifestViewer({
                   <ImageViewer
                     manifest={manifest}
                     currentCanvas={currentCanvasIndex}
-                    annotations={
-                      viewMode === 'annotation' ? localAnnotations : []
-                    }
+                    annotations={localAnnotations}
                     selectedAnnotationId={selectedAnnotationId}
                     onAnnotationSelect={setSelectedAnnotationId}
                     onViewerReady={() => {}}
                     showTextspotting={showTextspotting}
                     showIconography={showIconography}
+                    viewMode={viewMode}
                   />
                 )}
 
@@ -327,14 +331,13 @@ export function ManifestViewer({
                 <ImageViewer
                   manifest={manifest}
                   currentCanvas={currentCanvasIndex}
-                  annotations={
-                    mobileView === 'annotation' ? localAnnotations : []
-                  }
+                  annotations={localAnnotations}
                   selectedAnnotationId={selectedAnnotationId}
                   onAnnotationSelect={setSelectedAnnotationId}
                   onViewerReady={() => {}}
                   showTextspotting={showTextspotting}
                   showIconography={showIconography}
+                  viewMode={mobileView}
                 />
               )}
             {mobileView === 'map' && !isGalleryOpen && !isInfoOpen && (

--- a/components/ManifestViewer.tsx
+++ b/components/ManifestViewer.tsx
@@ -236,7 +236,6 @@ export function ManifestViewer({
                     onViewerReady={() => {}}
                     showTextspotting={showTextspotting}
                     showIconography={showIconography}
-                    viewMode={viewMode}
                   />
                 )}
 
@@ -337,7 +336,6 @@ export function ManifestViewer({
                   onViewerReady={() => {}}
                   showTextspotting={showTextspotting}
                   showIconography={showIconography}
-                  viewMode={mobileView}
                 />
               )}
             {mobileView === 'map' && !isGalleryOpen && !isInfoOpen && (

--- a/components/ManifestViewer.tsx
+++ b/components/ManifestViewer.tsx
@@ -1,36 +1,39 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
-import { Button } from '@/components/Button';
-import { Loader2, Info, MessageSquare, Map, Images, Image } from 'lucide-react';
-import { useToast } from '@/hooks/use-toast';
-import { CollectionSidebar } from '@/components/CollectionSidebar';
-import { TopNavigation } from '@/components/Navbar';
-import { StatusBar } from '@/components/StatusBar';
-import { normalizeManifest, getManifestCanvases } from '@/lib/iiif-helpers';
-import dynamic from 'next/dynamic';
-import type { Manifest } from '@/lib/types';
-import { ImageViewer } from '@/components/ImageViewer';
-import { useAllAnnotations } from '@/hooks/use-all-annotations';
 import { AnnotationList } from '@/components/AnnotationList';
-import type { Annotation } from '@/lib/types';
-import { useSession } from 'next-auth/react';
-import { useIsMobile } from '@/hooks/use-mobile';
+import { Button } from '@/components/Button';
+import { CollectionSidebar } from '@/components/CollectionSidebar';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/Dialog';
+import { Footer } from '@/components/Footer';
+import { ImageViewer } from '@/components/ImageViewer';
+import { ManifestLoader } from '@/components/ManifestLoader';
+import { TopNavigation } from '@/components/Navbar';
 import {
   Sheet,
   SheetContent,
   SheetHeader,
   SheetTitle,
 } from '@/components/Sheet';
+import { StatusBar } from '@/components/StatusBar';
+import { useAllAnnotations } from '@/hooks/use-all-annotations';
+import { useIsMobile } from '@/hooks/use-mobile';
+import { useToast } from '@/hooks/use-toast';
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-} from '@/components/Dialog';
-import { ManifestLoader } from '@/components/ManifestLoader';
-import { Footer } from '@/components/Footer';
+  getManifestCanvases,
+  mergeLocalAnnotations,
+  normalizeManifest,
+} from '@/lib/iiif-helpers';
+import type { Annotation, Manifest } from '@/lib/types';
+import { Image, Images, Info, Loader2, Map, MessageSquare } from 'lucide-react';
+import { useSession } from 'next-auth/react';
+import dynamic from 'next/dynamic';
+import React, { useEffect, useState } from 'react';
 
 const AllmapsMap = dynamic(() => import('./AllmapsMap'), { ssr: false });
 const MetadataSidebar = dynamic(
@@ -106,7 +109,10 @@ export function ManifestViewer({
       if (!res.ok) throw new Error(`Status ${res.status}`);
       const data = await res.json();
       const normalizedData = normalizeManifest(data);
-      setManifest(normalizedData);
+
+      const enrichedData = await mergeLocalAnnotations(normalizedData);
+
+      setManifest(enrichedData);
       toast({ title: 'Manifest loaded', description: data.label?.en?.[0] });
     } catch {
       try {
@@ -116,7 +122,10 @@ export function ManifestViewer({
         if (!res.ok) throw new Error(`Status ${res.status}`);
         const data = await res.json();
         const normalizedData = normalizeManifest(data);
-        setManifest(normalizedData);
+
+        const enrichedData = await mergeLocalAnnotations(normalizedData);
+
+        setManifest(enrichedData);
         toast({
           title: 'Static manifest loaded',
           description: data.label?.en?.[0],

--- a/components/ManifestViewer.tsx
+++ b/components/ManifestViewer.tsx
@@ -25,7 +25,9 @@ import { useAllAnnotations } from '@/hooks/use-all-annotations';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { useToast } from '@/hooks/use-toast';
 import {
+  getCanvasContentType,
   getManifestCanvases,
+  isImageCanvas,
   mergeLocalAnnotations,
   normalizeManifest,
 } from '@/lib/iiif-helpers';
@@ -218,7 +220,8 @@ export function ManifestViewer({
 
             <div className="flex-1 relative overflow-hidden">
               {(viewMode === 'image' || viewMode === 'annotation') &&
-                currentCanvas && (
+                currentCanvas &&
+                isImageCanvas(currentCanvas) && (
                   <ImageViewer
                     manifest={manifest}
                     currentCanvas={currentCanvasIndex}
@@ -232,6 +235,7 @@ export function ManifestViewer({
                     showIconography={showIconography}
                   />
                 )}
+
               {viewMode === 'map' && (
                 <AllmapsMap
                   manifest={manifest}

--- a/components/ManifestViewer.tsx
+++ b/components/ManifestViewer.tsx
@@ -448,7 +448,7 @@ export function ManifestViewer({
               Load IIIF Manifest
             </DialogTitle>
             <DialogDescription className="text-muted-foreground">
-              Load a different IIIF image collection to view and work with.
+              Load a different IIIF image manifest to view and work with.
             </DialogDescription>
           </DialogHeader>
           <ManifestLoader

--- a/components/ManifestViewer.tsx
+++ b/components/ManifestViewer.tsx
@@ -441,11 +441,13 @@ export function ManifestViewer({
           }
         }}
       >
-        <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
-          <DialogHeader>
-            <DialogTitle>Load IIIF Manifest</DialogTitle>
-            <DialogDescription>
-              Load a different IIIF manifest to view and work with.
+        <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto bg-card border-border shadow-2xl">
+          <DialogHeader className="border-b border-border pb-4">
+            <DialogTitle className="text-primary font-heading">
+              Load IIIF Manifest
+            </DialogTitle>
+            <DialogDescription className="text-muted-foreground">
+              Load a different IIIF image collection to view and work with.
             </DialogDescription>
           </DialogHeader>
           <ManifestLoader

--- a/components/ManifestViewer.tsx
+++ b/components/ManifestViewer.tsx
@@ -236,6 +236,7 @@ export function ManifestViewer({
                     onViewerReady={() => {}}
                     showTextspotting={showTextspotting}
                     showIconography={showIconography}
+                    viewMode={viewMode}
                   />
                 )}
 
@@ -336,6 +337,7 @@ export function ManifestViewer({
                   onViewerReady={() => {}}
                   showTextspotting={showTextspotting}
                   showIconography={showIconography}
+                  viewMode={mobileView}
                 />
               )}
             {mobileView === 'map' && !isGalleryOpen && !isInfoOpen && (

--- a/components/MapControls.tsx
+++ b/components/MapControls.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useState, useEffect, ChangeEvent } from 'react';
-import L from 'leaflet';
 import { cn } from '@/lib/utils';
+import L from 'leaflet';
 import { Menu, X } from 'lucide-react';
+import { ChangeEvent, useEffect, useState } from 'react';
 
 interface MapControlsProps {
   map: L.Map;
@@ -83,7 +83,7 @@ export function MapControls({
       <button
         onClick={() => setCollapsed(false)}
         className="
-          absolute top-4 right-4 z-[10000]
+          absolute top-4 right-4 z-[1001]
           p-2 bg-card/90 backdrop-blur-sm border border-border
           rounded-lg shadow hover:bg-card transition text-foreground
         "
@@ -98,7 +98,7 @@ export function MapControls({
     <div
       className={cn(
         `
-          absolute top-4 right-4 z-[10000] w-72
+          absolute top-4 right-4 z-[1001] w-72
           bg-card/95 backdrop-blur-sm border border-border
           rounded-xl shadow-lg p-4 space-y-4 text-sm text-card-foreground
         `,

--- a/components/MetadataSidebar.tsx
+++ b/components/MetadataSidebar.tsx
@@ -3,7 +3,6 @@
 import { Alert, AlertDescription, AlertTitle } from '@/components/Alert';
 import { Badge } from '@/components/Badge';
 import { Card, CardContent } from '@/components/Card';
-import { useAllAnnotations } from '@/hooks/use-all-annotations';
 import {
   extractAnnotations,
   getAllLocalizedValues,
@@ -18,12 +17,11 @@ import {
   MessageSquare,
 } from 'lucide-react';
 import React, { useEffect, useState } from 'react';
-import { AnnotationList } from './AnnotationList';
 
 interface MetadataSidebarProps {
   manifest: any;
   currentCanvas: number;
-  activeTab: 'metadata' | 'annotations' | 'geo';
+  activeTab: 'metadata' | 'geo';
   onChange: (m: any) => void;
 }
 
@@ -36,16 +34,6 @@ export function MetadataSidebar({
   const canvas = manifest.items?.[currentCanvas];
   const [allmapsAnno, setAllmapsAnno] = useState<any>(null);
   const [detailed, setDetailed] = useState<any>(null);
-  const [showTextspotting, setShowTextspotting] = useState(true);
-  const [showIconography, setShowIconography] = useState(true);
-
-  const handleFilterChange = (mot: 'textspotting' | 'iconography') => {
-    if (mot === 'textspotting') {
-      setShowTextspotting((v) => !v);
-    } else {
-      setShowIconography((v) => !v);
-    }
-  };
 
   const renderField = (label: string, content: React.ReactNode) => (
     <div>
@@ -74,24 +62,8 @@ export function MetadataSidebar({
     })();
   }, [canvas, activeTab, currentCanvas]);
 
-  if (activeTab === 'annotations') {
-    const { annotations, isLoading } = useAllAnnotations(canvas?.id ?? '');
-
-    return (
-      <div className="flex-1 flex flex-col overflow-hidden">
-        <AnnotationList
-          key={canvas?.id}
-          annotations={annotations}
-          isLoading={isLoading}
-          onAnnotationSelect={(id) => console.log('Selected annotation:', id)}
-          canEdit={false}
-          showTextspotting={showTextspotting}
-          showIconography={showIconography}
-          onFilterChange={handleFilterChange}
-        />
-      </div>
-    );
-  }
+  // Note: annotations tab is handled directly by AnnotationList in ManifestViewer
+  // This MetadataSidebar should only handle 'metadata' and 'geo' tabs
 
   if (activeTab === 'metadata') {
     return (

--- a/components/MetadataSidebar.tsx
+++ b/components/MetadataSidebar.tsx
@@ -1,20 +1,24 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
-import { Card, CardContent } from '@/components/Card';
+import { Alert, AlertDescription, AlertTitle } from '@/components/Alert';
 import { Badge } from '@/components/Badge';
-import { getLocalizedValue, extractAnnotations } from '@/lib/iiif-helpers';
+import { Card, CardContent } from '@/components/Card';
+import { useAllAnnotations } from '@/hooks/use-all-annotations';
+import {
+  extractAnnotations,
+  getAllLocalizedValues,
+  getLocalizedValue,
+} from '@/lib/iiif-helpers';
+import { formatDistanceToNow } from 'date-fns';
 import {
   BookOpen,
+  ExternalLink,
   Layers,
   Map as MapIcon,
   MessageSquare,
-  ExternalLink,
 } from 'lucide-react';
-import { formatDistanceToNow } from 'date-fns';
-import { Alert, AlertTitle, AlertDescription } from '@/components/Alert';
+import React, { useEffect, useState } from 'react';
 import { AnnotationList } from './AnnotationList';
-import { useAllAnnotations } from '@/hooks/use-all-annotations';
 
 interface MetadataSidebarProps {
   manifest: any;
@@ -101,7 +105,35 @@ export function MetadataSidebar({
             <Card className="shadow-none">
               <CardContent className="p-3 space-y-3 text-sm">
                 {manifest.label &&
-                  renderField('Title', getLocalizedValue(manifest.label))}
+                  (() => {
+                    const allLabels = getAllLocalizedValues(manifest.label);
+                    if (allLabels && allLabels.length > 1) {
+                      return (
+                        <div>
+                          <div className="font-medium text-xs text-muted-foreground">
+                            Title
+                          </div>
+                          <div className="space-y-2">
+                            {allLabels.map(({ language, value }, index) => (
+                              <div key={index}>
+                                <div className="text-xs text-muted-foreground font-medium uppercase tracking-wide">
+                                  {language}:
+                                </div>
+                                <div className="break-words whitespace-normal">
+                                  {value}
+                                </div>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      );
+                    } else {
+                      return renderField(
+                        'Title',
+                        getLocalizedValue(manifest.label),
+                      );
+                    }
+                  })()}
                 {(manifest.summary || manifest.description) &&
                   renderField(
                     'Description',
@@ -200,7 +232,35 @@ export function MetadataSidebar({
               <Card className="shadow-none">
                 <CardContent className="p-3 space-y-3 text-sm">
                   {canvas.label &&
-                    renderField('Title', getLocalizedValue(canvas.label))}
+                    (() => {
+                      const allLabels = getAllLocalizedValues(canvas.label);
+                      if (allLabels && allLabels.length > 1) {
+                        return (
+                          <div>
+                            <div className="font-medium text-xs text-muted-foreground">
+                              Title
+                            </div>
+                            <div className="space-y-2">
+                              {allLabels.map(({ language, value }, index) => (
+                                <div key={index}>
+                                  <div className="text-xs text-muted-foreground font-medium uppercase tracking-wide">
+                                    {language}:
+                                  </div>
+                                  <div className="break-words whitespace-normal">
+                                    {value}
+                                  </div>
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        );
+                      } else {
+                        return renderField(
+                          'Title',
+                          getLocalizedValue(canvas.label),
+                        );
+                      }
+                    })()}
                   {(canvas.width || canvas.height) &&
                     renderField(
                       'Dimensions',

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import React from 'react';
 import { Button } from '@/components/Button';
-import { PanelLeft, PanelRight, Folder } from 'lucide-react';
-import { getLocalizedValue } from '@/lib/iiif-helpers';
 import { useIsMobile } from '@/hooks/use-mobile';
+import { getLocalizedValue } from '@/lib/iiif-helpers';
+import { Folder, PanelLeft, PanelRight } from 'lucide-react';
+import React from 'react';
 
 interface TopNavigationProps {
   manifest: any;
@@ -47,10 +47,10 @@ export function TopNavigation({
             size="sm"
             onClick={onOpenManifestLoader}
             className="h-8 px-2 sm:h-10 sm:px-3"
-            title="Load different manifest"
+            title="Switch to a different manifest"
           >
             <Folder className="h-4 w-4 mr-1" />
-            <span className="hidden sm:inline">Load</span>
+            <span className="hidden sm:inline">Switch Manifest</span>
           </Button>
         )}
         {!isMobile && (

--- a/components/Toast.tsx
+++ b/components/Toast.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import * as React from 'react';
+import { cn } from '@/lib/utils';
 import * as ToastPrimitives from '@radix-ui/react-toast';
 import { X } from 'lucide-react';
-import { cn } from '@/lib/utils';
+import * as React from 'react';
 
 export const ToastProvider = ToastPrimitives.Provider;
 
@@ -16,7 +16,7 @@ export const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      'fixed top-0 z-50 flex w-full flex-col-reverse p-4',
+      'fixed top-0 z-[9999] flex w-full flex-col-reverse p-4',
       'sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-md',
       className,
     )}

--- a/hooks/use-all-annotations.ts
+++ b/hooks/use-all-annotations.ts
@@ -15,7 +15,6 @@ export function useAllAnnotations(canvasId: string) {
       return;
     }
 
-    // Do NOT clear annotations here for better perceived performance
     setIsLoading(true);
 
     (async () => {
@@ -23,7 +22,6 @@ export function useAllAnnotations(canvasId: string) {
       let page = 0;
       let more = true;
 
-      // First, fetch remote annotations from annorepo
       while (more && !cancelled) {
         try {
           const { items, hasMore } = await fetchAnnotations({
@@ -44,7 +42,6 @@ export function useAllAnnotations(canvasId: string) {
         if (localResponse.ok) {
           const { annotations: localAnnotations } = await localResponse.json();
           if (Array.isArray(localAnnotations)) {
-            // Filter local annotations for this canvas
             const canvasLocalAnnotations = localAnnotations.filter(
               (annotation: any) => {
                 const targetSource =

--- a/lib/annoRepo.ts
+++ b/lib/annoRepo.ts
@@ -21,8 +21,6 @@ export async function fetchAnnotations({
   const url = new URL(endpoint);
   url.searchParams.set('page', page.toString());
 
-  console.log('Annorepo fetch ▶', url.toString());
-
   const res = await fetch(url.toString());
   if (!res.ok) {
     const txt = await res.text().catch(() => '[no body]');
@@ -35,10 +33,6 @@ export async function fetchAnnotations({
   const items = Array.isArray(data.items) ? data.items : [];
 
   const hasMore = typeof data.next === 'string';
-
-  console.log(
-    `Annorepo returned ${items.length} items (page ${page}), hasMore=${hasMore}`,
-  );
 
   return { items, hasMore };
 }

--- a/lib/iiif-helpers.ts
+++ b/lib/iiif-helpers.ts
@@ -367,7 +367,6 @@ export async function mergeLocalAnnotations(
       canvas.annotations.push(localAnnotationPage);
     }
 
-    console.log(`Merged ${annotations.length} local annotations into manifest`);
     return clonedManifest;
   } catch (error) {
     console.error('Error merging local annotations:', error);

--- a/lib/iiif-helpers.ts
+++ b/lib/iiif-helpers.ts
@@ -31,6 +31,62 @@ export function getLocalizedValue(languageMap: any, preferredLanguage = 'en') {
   return null;
 }
 
+export function getAllLocalizedValues(
+  languageMap: any,
+): { language: string; value: string }[] | null {
+  if (!languageMap) return null;
+
+  if (typeof languageMap === 'string')
+    return [{ language: 'none', value: languageMap }];
+
+  if (Array.isArray(languageMap))
+    return [{ language: 'none', value: languageMap.join(', ') }];
+
+  if (typeof languageMap === 'object') {
+    const results: { language: string; value: string }[] = [];
+
+    const languageNames: { [key: string]: string } = {
+      en: 'English',
+      nl: 'Dutch',
+      de: 'German',
+      fr: 'French',
+      es: 'Spanish',
+      it: 'Italian',
+      pt: 'Portuguese',
+      ru: 'Russian',
+      zh: 'Chinese',
+      ja: 'Japanese',
+      ko: 'Korean',
+      ar: 'Arabic',
+      none: 'No language specified',
+    };
+
+    const languages = Object.keys(languageMap).sort((a, b) => {
+      if (a === 'en') return -1;
+      if (b === 'en') return 1;
+      if (a === 'none') return 1;
+      if (b === 'none') return -1;
+      return a.localeCompare(b);
+    });
+
+    for (const lang of languages) {
+      const value = languageMap[lang];
+      if (value) {
+        const displayValue = Array.isArray(value) ? value.join(', ') : value;
+        const languageDisplay = languageNames[lang] || lang.toUpperCase();
+        results.push({
+          language: languageDisplay,
+          value: displayValue,
+        });
+      }
+    }
+
+    return results.length > 0 ? results : null;
+  }
+
+  return null;
+}
+
 export function normalizeManifest(manifest: any): Manifest {
   if (manifest.items) {
     return manifest;

--- a/lib/iiif-helpers.ts
+++ b/lib/iiif-helpers.ts
@@ -116,7 +116,6 @@ export function getManifestCanvases(manifest: any) {
 export function getCanvasImageInfo(canvas: any) {
   if (!canvas) return { service: null, url: null };
 
-  // IIIF v3 structure
   if (canvas.items) {
     const items = canvas.items?.[0]?.items || [];
     return items.reduce(
@@ -139,7 +138,6 @@ export function getCanvasImageInfo(canvas: any) {
     );
   }
 
-  // IIIF v2 structure
   if (canvas.images) {
     const image = canvas.images[0];
     if (image?.resource) {
@@ -174,7 +172,6 @@ export function extractGeoData(canvas: any) {
     for (const annoPage of canvas.annotations) {
       if (annoPage.items) {
         for (const anno of annoPage.items) {
-          // Check for georeferencing motivation
           if (
             anno.motivation === 'georeferencing' ||
             (anno.body && anno.body.type === 'GeoJSON') ||
@@ -204,7 +201,6 @@ export function extractGeoData(canvas: any) {
                   geoData.allmapsId = geoJson._allmaps.id;
                 }
 
-                // Extract control points for manual overlay
                 if (geoJson.features && Array.isArray(geoJson.features)) {
                   geoData.controlPoints = geoJson.features.filter(
                     (f: any) => f.properties && f.properties.resourceCoords,

--- a/lib/manifest-validator.ts
+++ b/lib/manifest-validator.ts
@@ -1,0 +1,175 @@
+import type { Manifest } from './types';
+
+export interface ValidationResult {
+  isValid: boolean;
+  warnings: string[];
+  errors: string[];
+  metadata: {
+    version: 'v2' | 'v3' | 'unknown';
+    hasImages: boolean;
+    hasAnnotations: boolean;
+    hasGeoreferencing: boolean;
+    canvasCount: number;
+    annotationCount: number;
+  };
+}
+
+export function validateManifest(data: any): ValidationResult {
+  const result: ValidationResult = {
+    isValid: true,
+    warnings: [],
+    errors: [],
+    metadata: {
+      version: 'unknown',
+      hasImages: false,
+      hasAnnotations: false,
+      hasGeoreferencing: false,
+      canvasCount: 0,
+      annotationCount: 0,
+    },
+  };
+
+  // Basic structure validation
+  if (!data) {
+    result.errors.push('Manifest data is empty or null');
+    result.isValid = false;
+    return result;
+  }
+
+  // Version detection
+  const context = data['@context'];
+  const isV2 =
+    context &&
+    (Array.isArray(context)
+      ? context.some(
+          (c: string) =>
+            c.includes('api/presentation/2') || c.includes('shared-canvas.org'),
+        )
+      : context.includes('api/presentation/2') ||
+        context.includes('shared-canvas.org'));
+
+  const isV3 =
+    context &&
+    (Array.isArray(context)
+      ? context.some((c: string) => c.includes('api/presentation/3'))
+      : context.includes('api/presentation/3'));
+
+  const hasV2Structure = data['@type'] === 'sc:Manifest' && data.sequences;
+
+  if (isV3) {
+    result.metadata.version = 'v3';
+    if (data.type !== 'Manifest') {
+      result.errors.push('IIIF v3 manifest must have type "Manifest"');
+      result.isValid = false;
+    }
+  } else if (isV2 || hasV2Structure) {
+    result.metadata.version = 'v2';
+    if (data['@type'] !== 'sc:Manifest') {
+      result.errors.push('IIIF v2 manifest must have @type "sc:Manifest"');
+      result.isValid = false;
+    }
+  } else {
+    result.warnings.push(
+      'Could not determine IIIF version - may not be a valid IIIF manifest',
+    );
+  }
+
+  // Required fields
+  if (!data.id && !data['@id']) {
+    result.errors.push('Manifest missing required id property');
+    result.isValid = false;
+  }
+
+  if (!data.label) {
+    result.errors.push('Manifest missing required label property');
+    result.isValid = false;
+  }
+
+  // Content validation
+  let canvases: any[] = [];
+  if (result.metadata.version === 'v3' && data.items) {
+    canvases = data.items;
+    result.metadata.hasImages = canvases.length > 0;
+  } else if (
+    result.metadata.version === 'v2' &&
+    data.sequences?.[0]?.canvases
+  ) {
+    canvases = data.sequences[0].canvases;
+    result.metadata.hasImages = canvases.length > 0;
+  }
+
+  result.metadata.canvasCount = canvases.length;
+
+  if (canvases.length === 0) {
+    result.errors.push(
+      'Manifest contains no viewable content (no canvases found)',
+    );
+    result.isValid = false;
+  }
+
+  // Analyze annotations and georeferencing
+  let totalAnnotations = 0;
+  let hasGeoref = false;
+
+  canvases.forEach((canvas) => {
+    if (canvas.annotations) {
+      canvas.annotations.forEach((annoPage: any) => {
+        if (annoPage.items) {
+          totalAnnotations += annoPage.items.length;
+          annoPage.items.forEach((anno: any) => {
+            if (
+              anno.motivation === 'georeferencing' ||
+              (anno.body && anno.body.type === 'GeoJSON') ||
+              anno.body?.value?.includes('allmaps')
+            ) {
+              hasGeoref = true;
+            }
+          });
+        }
+      });
+    }
+  });
+
+  result.metadata.annotationCount = totalAnnotations;
+  result.metadata.hasAnnotations = totalAnnotations > 0;
+  result.metadata.hasGeoreferencing = hasGeoref;
+
+  // Helpful warnings
+  if (result.metadata.canvasCount > 100) {
+    result.warnings.push(
+      `Large collection with ${result.metadata.canvasCount} items - may take time to load`,
+    );
+  }
+
+  if (!result.metadata.hasAnnotations) {
+    result.warnings.push('No annotations found - some features may be limited');
+  }
+
+  if (result.metadata.hasGeoreferencing) {
+    result.warnings.push(
+      'Georeferencing data detected - map view will be available',
+    );
+  }
+
+  return result;
+}
+
+export function getValidationSummary(validation: ValidationResult): string {
+  const { metadata } = validation;
+
+  let summary = `IIIF ${metadata.version} collection with ${
+    metadata.canvasCount
+  } item${metadata.canvasCount !== 1 ? 's' : ''}`;
+
+  const features = [];
+  if (metadata.hasImages) features.push('images');
+  if (metadata.hasAnnotations)
+    features.push(`${metadata.annotationCount} annotations`);
+  if (metadata.hasGeoreferencing) features.push('map data');
+
+  if (features.length > 0) {
+    summary += ` (${features.join(', ')})`;
+  }
+
+  return summary;
+}

--- a/lib/manifest-validator.ts
+++ b/lib/manifest-validator.ts
@@ -5,7 +5,7 @@ function isSingleCanvas(data: any): boolean {
     data &&
     (data['@type'] === 'sc:Canvas' || data.type === 'Canvas') &&
     (data['@id'] || data.id) &&
-    (data.images || data.items) // Has content
+    (data.images || data.items)
   );
 }
 

--- a/lib/manifest-validator.ts
+++ b/lib/manifest-validator.ts
@@ -109,7 +109,7 @@ export interface ValidationResult {
     annotationCount: number;
     mediaTypes: string[];
   };
-  autoWrapped?: boolean; // Indicates if we auto-wrapped a single canvas
+  autoWrapped?: boolean; 
 }
 
 export function validateManifest(data: any): ValidationResult {
@@ -130,7 +130,6 @@ export function validateManifest(data: any): ValidationResult {
     },
   };
 
-  // Basic structure validation
   if (!data) {
     result.errors.push('Manifest data is empty or null');
     result.isValid = false;
@@ -152,7 +151,6 @@ export function validateManifest(data: any): ValidationResult {
     };
   }
 
-  // Version detection
   const context = data['@context'];
   const isV2 =
     context &&
@@ -200,7 +198,6 @@ export function validateManifest(data: any): ValidationResult {
     result.isValid = false;
   }
 
-  // Content validation
   let canvases: any[] = [];
   if (result.metadata.version === 'v3' && data.items) {
     canvases = data.items;

--- a/package.json
+++ b/package.json
@@ -76,6 +76,8 @@
     "@types/pg": "^8.11.14",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "eslint": "^9",
+    "eslint-config-next": "15.3.4",
     "postcss": "^8.5.3",
     "tailwindcss": "^3.4.17",
     "typescript": "^5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,12 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.1.2(@types/react@19.1.2)
+      eslint:
+        specifier: ^9
+        version: 9.30.1(jiti@1.21.7)
+      eslint-config-next:
+        specifier: 15.3.4
+        version: 15.3.4(eslint@9.30.1(jiti@1.21.7))(typescript@5.8.3)
       postcss:
         specifier: ^8.5.3
         version: 8.5.3
@@ -255,8 +261,56 @@ packages:
     resolution: {integrity: sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==}
     engines: {node: '>=6.9.0'}
 
+  '@emnapi/core@1.4.3':
+    resolution: {integrity: sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==}
+
   '@emnapi/runtime@1.4.3':
     resolution: {integrity: sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==}
+
+  '@emnapi/wasi-threads@1.0.2':
+    resolution: {integrity: sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==}
+
+  '@eslint-community/eslint-utils@4.7.0':
+    resolution: {integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.1':
+    resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.21.0':
+    resolution: {integrity: sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.3.0':
+    resolution: {integrity: sha512-ViuymvFmcJi04qdZeDc2whTHryouGcDlaxPqarTD0ZE10ISpxGUVZGZDx4w01upyIynL3iu6IXH2bS1NhclQMw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.14.0':
+    resolution: {integrity: sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.15.1':
+    resolution: {integrity: sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/eslintrc@3.3.1':
+    resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.30.1':
+    resolution: {integrity: sha512-zXhuECFlyep42KZUhWjfvsmXGX39W8K8LFb8AWXM9gSV9dQB+MrJGLKvW6Zw0Ggnbpw0VHTtrhFXYe3Gym18jg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.6':
+    resolution: {integrity: sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.3.3':
+    resolution: {integrity: sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@floating-ui/core@1.6.9':
     resolution: {integrity: sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==}
@@ -277,6 +331,26 @@ packages:
     resolution: {integrity: sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==}
     peerDependencies:
       react-hook-form: ^7.0.0
+
+  '@humanfs/core@0.19.1':
+    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.6':
+    resolution: {integrity: sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.3.1':
+    resolution: {integrity: sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==}
+    engines: {node: '>=18.18'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
 
   '@img/sharp-darwin-arm64@0.33.5':
     resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
@@ -405,8 +479,14 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
+  '@napi-rs/wasm-runtime@0.2.11':
+    resolution: {integrity: sha512-9DPkXtvHydrcOsopiYpUgPHpmj0HWZKMUnL2dZqpvC42lsratuBG06V5ipyno0fUek5VlFsNQ+AcFATSrJXgMA==}
+
   '@next/env@15.2.4':
     resolution: {integrity: sha512-+SFtMgoiYP3WoSswuNmxJOCwi06TdWE733D+WPjpXIe4LXGULwEaofiiAy6kbS0+XjM5xF5n3lKuBwN2SnqD9g==}
+
+  '@next/eslint-plugin-next@15.3.4':
+    resolution: {integrity: sha512-lBxYdj7TI8phbJcLSAqDt57nIcobEign5NYIKCiy0hXQhrUbTqLqOaSDi568U6vFg4hJfBdZYsG4iP/uKhCqgg==}
 
   '@next/swc-darwin-arm64@15.2.4':
     resolution: {integrity: sha512-1AnMfs655ipJEDC/FHkSr0r3lXBgpqKo4K1kiwfUf3iE68rDFXZ1TtHdMvf7D0hMItgDZ7Vuq3JgNMbt/+3bYw==}
@@ -467,6 +547,10 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@nolyfill/is-core-module@1.0.39':
+    resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
+    engines: {node: '>=12.4.0'}
 
   '@panva/hkdf@1.2.1':
     resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
@@ -1107,6 +1191,12 @@ packages:
     resolution: {integrity: sha512-C7c51Nn4yTxXFKvgh2txJFNweaVcfUPQxwEUFw4aWsCmfiBDJsTSwviIF8EcwjQ6k8bPyMWCl1vw4BdxE569Cg==}
     engines: {node: '>= 10'}
 
+  '@rtsao/scc@1.1.0':
+    resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@rushstack/eslint-patch@1.12.0':
+    resolution: {integrity: sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==}
+
   '@shuding/opentype.js@1.4.0-beta.0':
     resolution: {integrity: sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==}
     engines: {node: '>= 8.0.0'}
@@ -1139,6 +1229,9 @@ packages:
   '@turf/midpoint@6.5.0':
     resolution: {integrity: sha512-MyTzV44IwmVI6ec9fB2OgZ53JGNlgOpaYl9ArKoF49rXpL84F9rNATndbe0+MQIhdkw8IlzA6xVP4lZzfMNVCw==}
 
+  '@tybys/wasm-util@0.9.0':
+    resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
+
   '@types/d3-array@3.2.1':
     resolution: {integrity: sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==}
 
@@ -1166,8 +1259,17 @@ packages:
   '@types/d3-timer@3.0.2':
     resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
 
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/json5@0.0.29':
+    resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
   '@types/leaflet@1.9.17':
     resolution: {integrity: sha512-IJ4K6t7I3Fh5qXbQ1uwL3CFVbCi6haW9+53oLWgdKlLP7EaS21byWFJxxqOx9y8I0AP0actXSJLVMbyvxhkUTA==}
@@ -1189,9 +1291,176 @@ packages:
   '@types/react@19.1.2':
     resolution: {integrity: sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==}
 
+  '@typescript-eslint/eslint-plugin@8.35.1':
+    resolution: {integrity: sha512-9XNTlo7P7RJxbVeICaIIIEipqxLKguyh+3UbXuT2XQuFp6d8VOeDEGuz5IiX0dgZo8CiI6aOFLg4e8cF71SFVg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.35.1
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/parser@8.35.1':
+    resolution: {integrity: sha512-3MyiDfrfLeK06bi/g9DqJxP5pV74LNv4rFTyvGDmT3x2p1yp1lOd+qYZfiRPIOf/oON+WRZR5wxxuF85qOar+w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/project-service@8.35.1':
+    resolution: {integrity: sha512-VYxn/5LOpVxADAuP3NrnxxHYfzVtQzLKeldIhDhzC8UHaiQvYlXvKuVho1qLduFbJjjy5U5bkGwa3rUGUb1Q6Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/scope-manager@8.35.1':
+    resolution: {integrity: sha512-s/Bpd4i7ht2934nG+UoSPlYXd08KYz3bmjLEb7Ye1UVob0d1ENiT3lY8bsCmik4RqfSbPw9xJJHbugpPpP5JUg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.35.1':
+    resolution: {integrity: sha512-K5/U9VmT9dTHoNowWZpz+/TObS3xqC5h0xAIjXPw+MNcKV9qg6eSatEnmeAwkjHijhACH0/N7bkhKvbt1+DXWQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/type-utils@8.35.1':
+    resolution: {integrity: sha512-HOrUBlfVRz5W2LIKpXzZoy6VTZzMu2n8q9C2V/cFngIC5U1nStJgv0tMV4sZPzdf4wQm9/ToWUFPMN9Vq9VJQQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/types@8.35.1':
+    resolution: {integrity: sha512-q/O04vVnKHfrrhNAscndAn1tuQhIkwqnaW+eu5waD5IPts2eX1dgJxgqcPx5BX109/qAz7IG6VrEPTOYKCNfRQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.35.1':
+    resolution: {integrity: sha512-Vvpuvj4tBxIka7cPs6Y1uvM7gJgdF5Uu9F+mBJBPY4MhvjrjWGK4H0lVgLJd/8PWZ23FTqsaJaLEkBCFUk8Y9g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/utils@8.35.1':
+    resolution: {integrity: sha512-lhnwatFmOFcazAsUm3ZnZFpXSxiwoa1Lj50HphnDe1Et01NF4+hrdXONSUHIcbVu2eFb1bAf+5yjXkGVkXBKAQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/visitor-keys@8.35.1':
+    resolution: {integrity: sha512-VRwixir4zBWCSTP/ljEo091lbpypz57PoeAQ9imjG+vbeof9LplljsL1mos4ccG6H9IjfrVGM359RozUnuFhpw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@unrs/resolver-binding-android-arm-eabi@1.9.2':
+    resolution: {integrity: sha512-tS+lqTU3N0kkthU+rYp0spAYq15DU8ld9kXkaKg9sbQqJNF+WPMuNHZQGCgdxrUOEO0j22RKMwRVhF1HTl+X8A==}
+    cpu: [arm]
+    os: [android]
+
+  '@unrs/resolver-binding-android-arm64@1.9.2':
+    resolution: {integrity: sha512-MffGiZULa/KmkNjHeuuflLVqfhqLv1vZLm8lWIyeADvlElJ/GLSOkoUX+5jf4/EGtfwrNFcEaB8BRas03KT0/Q==}
+    cpu: [arm64]
+    os: [android]
+
+  '@unrs/resolver-binding-darwin-arm64@1.9.2':
+    resolution: {integrity: sha512-dzJYK5rohS1sYl1DHdJ3mwfwClJj5BClQnQSyAgEfggbUwA9RlROQSSbKBLqrGfsiC/VyrDPtbO8hh56fnkbsQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@unrs/resolver-binding-darwin-x64@1.9.2':
+    resolution: {integrity: sha512-gaIMWK+CWtXcg9gUyznkdV54LzQ90S3X3dn8zlh+QR5Xy7Y+Efqw4Rs4im61K1juy4YNb67vmJsCDAGOnIeffQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@unrs/resolver-binding-freebsd-x64@1.9.2':
+    resolution: {integrity: sha512-S7QpkMbVoVJb0xwHFwujnwCAEDe/596xqY603rpi/ioTn9VDgBHnCCxh+UFrr5yxuMH+dliHfjwCZJXOPJGPnw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@unrs/resolver-binding-linux-arm-gnueabihf@1.9.2':
+    resolution: {integrity: sha512-+XPUMCuCCI80I46nCDFbGum0ZODP5NWGiwS3Pj8fOgsG5/ctz+/zzuBlq/WmGa+EjWZdue6CF0aWWNv84sE1uw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm-musleabihf@1.9.2':
+    resolution: {integrity: sha512-sqvUyAd1JUpwbz33Ce2tuTLJKM+ucSsYpPGl2vuFwZnEIg0CmdxiZ01MHQ3j6ExuRqEDUCy8yvkDKvjYFPb8Zg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm64-gnu@1.9.2':
+    resolution: {integrity: sha512-UYA0MA8ajkEDCFRQdng/FVx3F6szBvk3EPnkTTQuuO9lV1kPGuTB+V9TmbDxy5ikaEgyWKxa4CI3ySjklZ9lFA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm64-musl@1.9.2':
+    resolution: {integrity: sha512-P/CO3ODU9YJIHFqAkHbquKtFst0COxdphc8TKGL5yCX75GOiVpGqd1d15ahpqu8xXVsqP4MGFP2C3LRZnnL5MA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-ppc64-gnu@1.9.2':
+    resolution: {integrity: sha512-uKStFlOELBxBum2s1hODPtgJhY4NxYJE9pAeyBgNEzHgTqTiVBPjfTlPFJkfxyTjQEuxZbbJlJnMCrRgD7ubzw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-riscv64-gnu@1.9.2':
+    resolution: {integrity: sha512-LkbNnZlhINfY9gK30AHs26IIVEZ9PEl9qOScYdmY2o81imJYI4IMnJiW0vJVtXaDHvBvxeAgEy5CflwJFIl3tQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-riscv64-musl@1.9.2':
+    resolution: {integrity: sha512-vI+e6FzLyZHSLFNomPi+nT+qUWN4YSj8pFtQZSFTtmgFoxqB6NyjxSjAxEC1m93qn6hUXhIsh8WMp+fGgxCoRg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-s390x-gnu@1.9.2':
+    resolution: {integrity: sha512-sSO4AlAYhSM2RAzBsRpahcJB1msc6uYLAtP6pesPbZtptF8OU/CbCPhSRW6cnYOGuVmEmWVW5xVboAqCnWTeHQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-x64-gnu@1.9.2':
+    resolution: {integrity: sha512-jkSkwch0uPFva20Mdu8orbQjv2A3G88NExTN2oPTI1AJ+7mZfYW3cDCTyoH6OnctBKbBVeJCEqh0U02lTkqD5w==}
+    cpu: [x64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-x64-musl@1.9.2':
+    resolution: {integrity: sha512-Uk64NoiTpQbkpl+bXsbeyOPRpUoMdcUqa+hDC1KhMW7aN1lfW8PBlBH4mJ3n3Y47dYE8qi0XTxy1mBACruYBaw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@unrs/resolver-binding-wasm32-wasi@1.9.2':
+    resolution: {integrity: sha512-EpBGwkcjDicjR/ybC0g8wO5adPNdVuMrNalVgYcWi+gYtC1XYNuxe3rufcO7dA76OHGeVabcO6cSkPJKVcbCXQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@unrs/resolver-binding-win32-arm64-msvc@1.9.2':
+    resolution: {integrity: sha512-EdFbGn7o1SxGmN6aZw9wAkehZJetFPao0VGZ9OMBwKx6TkvDuj6cNeLimF/Psi6ts9lMOe+Dt6z19fZQ9Ye2fw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@unrs/resolver-binding-win32-ia32-msvc@1.9.2':
+    resolution: {integrity: sha512-JY9hi1p7AG+5c/dMU8o2kWemM8I6VZxfGwn1GCtf3c5i+IKcMo2NQ8OjZ4Z3/itvY/Si3K10jOBQn7qsD/whUA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@unrs/resolver-binding-win32-x64-msvc@1.9.2':
+    resolution: {integrity: sha512-ryoo+EB19lMxAd80ln9BVf8pdOAxLb97amrQ3SFN9OCRn/5M5wvwDgAe4i8ZjhpbiHoDeP8yavcTEnpKBo7lZg==}
+    cpu: [x64]
+    os: [win32]
+
   '@vercel/og@0.6.8':
     resolution: {integrity: sha512-e4kQK9mP8ntpo3dACWirGod/hHv4qO5JMj9a/0a2AZto7b4persj5YP7t1Er372gTtYFTYxNhMx34jRvHooglw==}
     engines: {node: '>=16'}
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.12.6:
+    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -1219,9 +1488,55 @@ packages:
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
   aria-hidden@1.2.4:
     resolution: {integrity: sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
+
+  array-buffer-byte-length@1.0.2:
+    resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
+    engines: {node: '>= 0.4'}
+
+  array-includes@3.1.9:
+    resolution: {integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.findlast@1.2.5:
+    resolution: {integrity: sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.findlastindex@1.2.6:
+    resolution: {integrity: sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.flat@1.3.3:
+    resolution: {integrity: sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.flatmap@1.3.3:
+    resolution: {integrity: sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.tosorted@1.1.4:
+    resolution: {integrity: sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==}
+    engines: {node: '>= 0.4'}
+
+  arraybuffer.prototype.slice@1.0.4:
+    resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
+    engines: {node: '>= 0.4'}
+
+  ast-types-flow@0.0.8:
+    resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
+
+  async-function@1.0.0:
+    resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
+    engines: {node: '>= 0.4'}
 
   autoprefixer@10.4.21:
     resolution: {integrity: sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==}
@@ -1229,6 +1544,18 @@ packages:
     hasBin: true
     peerDependencies:
       postcss: ^8.1.0
+
+  available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
+
+  axe-core@4.10.3:
+    resolution: {integrity: sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==}
+    engines: {node: '>=4'}
+
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
+    engines: {node: '>= 0.4'}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -1240,6 +1567,9 @@ packages:
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
+
+  brace-expansion@1.1.12:
+    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
   brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
@@ -1257,6 +1587,22 @@ packages:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
 
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bind@1.0.8:
+    resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
   camelcase-css@2.0.1:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
@@ -1266,6 +1612,10 @@ packages:
 
   caniuse-lite@1.0.30001715:
     resolution: {integrity: sha512-7ptkFGMm2OAOgvZpwgA4yjQ5SQbrNVGdRjzH0pBdy1Fasvcr+KAeECmbCAECzTuDuoX0FCY8KzUxjf9+9kfZEw==}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -1307,6 +1657,9 @@ packages:
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
@@ -1385,11 +1738,54 @@ packages:
     resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
     engines: {node: '>=12'}
 
+  damerau-levenshtein@1.0.8:
+    resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-view-buffer@1.0.2:
+    resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
+    engines: {node: '>= 0.4'}
+
+  data-view-byte-length@1.0.2:
+    resolution: {integrity: sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==}
+    engines: {node: '>= 0.4'}
+
+  data-view-byte-offset@1.0.1:
+    resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
+    engines: {node: '>= 0.4'}
+
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
+  debug@3.2.7:
+    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.4.1:
+    resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   decimal.js-light@2.5.1:
     resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
+  define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
 
   detect-libc@2.0.4:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
@@ -1403,6 +1799,10 @@ packages:
 
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+
+  doctrine@2.1.0:
+    resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
+    engines: {node: '>=0.10.0'}
 
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
@@ -1496,6 +1896,10 @@ packages:
       sqlite3:
         optional: true
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -1524,6 +1928,38 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  es-abstract@1.24.0:
+    resolution: {integrity: sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==}
+    engines: {node: '>= 0.4'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-iterator-helpers@1.2.1:
+    resolution: {integrity: sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  es-shim-unscopables@1.1.0:
+    resolution: {integrity: sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==}
+    engines: {node: '>= 0.4'}
+
+  es-to-primitive@1.3.0:
+    resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
+    engines: {node: '>= 0.4'}
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -1531,26 +1967,186 @@ packages:
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-config-next@15.3.4:
+    resolution: {integrity: sha512-WqeumCq57QcTP2lYlV6BRUySfGiBYEXlQ1L0mQ+u4N4X4ZhUVSSQ52WtjqHv60pJ6dD7jn+YZc0d1/ZSsxccvg==}
+    peerDependencies:
+      eslint: ^7.23.0 || ^8.0.0 || ^9.0.0
+      typescript: '>=3.3.1'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  eslint-import-resolver-node@0.3.9:
+    resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
+
+  eslint-import-resolver-typescript@3.10.1:
+    resolution: {integrity: sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      eslint-plugin-import: '*'
+      eslint-plugin-import-x: '*'
+    peerDependenciesMeta:
+      eslint-plugin-import:
+        optional: true
+      eslint-plugin-import-x:
+        optional: true
+
+  eslint-module-utils@2.12.1:
+    resolution: {integrity: sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+
+  eslint-plugin-import@2.32.0:
+    resolution: {integrity: sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+
+  eslint-plugin-jsx-a11y@6.10.2:
+    resolution: {integrity: sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
+
+  eslint-plugin-react-hooks@5.2.0:
+    resolution: {integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
+
+  eslint-plugin-react@7.37.5:
+    resolution: {integrity: sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
+
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint@9.30.1:
+    resolution: {integrity: sha512-zmxXPNMOXmwm9E0yQLi5uqXHs7uq2UIiqEKo3Gq+3fwo1XrJ+hijAZImyF7hclW3E6oHz43Yk3RP8at6OTKflQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  esquery@1.6.0:
+    resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
   fast-equals@5.2.2:
     resolution: {integrity: sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==}
     engines: {node: '>=6.0.0'}
 
+  fast-glob@3.3.1:
+    resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
+    engines: {node: '>=8.6.0'}
+
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
+
+  fdir@6.4.6:
+    resolution: {integrity: sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   fflate@0.7.4:
     resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
 
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.3.3:
+    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+
+  for-each@0.3.5:
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -1570,9 +2166,31 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  function.prototype.name@1.1.8:
+    resolution: {integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==}
+    engines: {node: '>= 0.4'}
+
+  functions-have-names@1.2.3:
+    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  get-symbol-description@1.1.0:
+    resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
+    engines: {node: '>= 0.4'}
+
+  get-tsconfig@4.10.1:
+    resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -1586,6 +2204,44 @@ packages:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
     hasBin: true
 
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  globalthis@1.0.4:
+    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  graphemer@1.4.0:
+    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  has-bigints@1.1.0:
+    resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
+    engines: {node: '>= 0.4'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
+  has-proto@1.2.0:
+    resolution: {integrity: sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
@@ -1593,6 +2249,22 @@ packages:
   hex-rgb@4.3.0:
     resolution: {integrity: sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==}
     engines: {node: '>=6'}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
 
   inherits@2.0.3:
     resolution: {integrity: sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==}
@@ -1603,6 +2275,10 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
+  internal-slot@1.1.0:
+    resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
+    engines: {node: '>= 0.4'}
+
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
@@ -1610,35 +2286,129 @@ packages:
   is-any-array@2.0.1:
     resolution: {integrity: sha512-UtilS7hLRu++wb/WBAw9bNuP1Eg04Ivn1vERJck8zJthEvXCBEBpGR/33u/xLKWEQf95803oalHrVDptcAvFdQ==}
 
+  is-array-buffer@3.0.5:
+    resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
+    engines: {node: '>= 0.4'}
+
   is-arrayish@0.3.2:
     resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
+
+  is-async-function@2.1.1:
+    resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
+    engines: {node: '>= 0.4'}
+
+  is-bigint@1.1.0:
+    resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
+    engines: {node: '>= 0.4'}
 
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
 
+  is-boolean-object@1.2.2:
+    resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
+    engines: {node: '>= 0.4'}
+
+  is-bun-module@2.0.0:
+    resolution: {integrity: sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==}
+
+  is-callable@1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
+
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+    engines: {node: '>= 0.4'}
+
+  is-data-view@1.0.2:
+    resolution: {integrity: sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==}
+    engines: {node: '>= 0.4'}
+
+  is-date-object@1.1.0:
+    resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
     engines: {node: '>= 0.4'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
 
+  is-finalizationregistry@1.1.1:
+    resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
+    engines: {node: '>= 0.4'}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
+
+  is-generator-function@1.1.0:
+    resolution: {integrity: sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==}
+    engines: {node: '>= 0.4'}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-map@2.0.3:
+    resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
+    engines: {node: '>= 0.4'}
+
+  is-negative-zero@2.0.3:
+    resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
+    engines: {node: '>= 0.4'}
+
+  is-number-object@1.1.1:
+    resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
+    engines: {node: '>= 0.4'}
+
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-regex@1.2.1:
+    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
+    engines: {node: '>= 0.4'}
+
+  is-set@2.0.3:
+    resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
+    engines: {node: '>= 0.4'}
+
+  is-shared-array-buffer@1.0.4:
+    resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
+    engines: {node: '>= 0.4'}
+
+  is-string@1.1.1:
+    resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
+    engines: {node: '>= 0.4'}
+
+  is-symbol@1.1.1:
+    resolution: {integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==}
+    engines: {node: '>= 0.4'}
+
+  is-typed-array@1.1.15:
+    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
+    engines: {node: '>= 0.4'}
+
+  is-weakmap@2.0.2:
+    resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
+    engines: {node: '>= 0.4'}
+
+  is-weakref@1.1.1:
+    resolution: {integrity: sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==}
+    engines: {node: '>= 0.4'}
+
+  is-weakset@2.0.4:
+    resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
+    engines: {node: '>= 0.4'}
+
+  isarray@2.0.5:
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  iterator.prototype@1.1.5:
+    resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
+    engines: {node: '>= 0.4'}
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
@@ -1653,8 +2423,43 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-yaml@4.1.0:
+    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+    hasBin: true
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json5@1.0.2:
+    resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
+    hasBin: true
+
+  jsx-ast-utils@3.3.5:
+    resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
+    engines: {node: '>=4.0'}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  language-subtag-registry@0.3.23:
+    resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
+
+  language-tags@1.0.9:
+    resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
+    engines: {node: '>=0.10'}
+
   leaflet@1.9.4:
     resolution: {integrity: sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -1666,8 +2471,15 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
   lodash-es@4.17.21:
     resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
@@ -1688,6 +2500,10 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -1696,9 +2512,15 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  minimatch@3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
@@ -1719,6 +2541,9 @@ packages:
   monaco-editor@0.52.2:
     resolution: {integrity: sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==}
 
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
@@ -1726,6 +2551,14 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  napi-postinstall@0.2.5:
+    resolution: {integrity: sha512-kmsgUvCRIJohHjbZ3V8avP0I1Pekw329MVAMDzVxsrkjgdnqiwvMX5XwR+hWV66vsAtZ+iM+fVnq8RTQawUmCQ==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+    hasBin: true
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
   next-auth@4.24.11:
     resolution: {integrity: sha512-pCFXzIDQX7xmHFs4KVH4luCjaCbuPRtZ9oBUjUhOk84mZ9WVPf94n87TxYI4rSRf9HmfHEF8Yep3JrYDVOo3Cw==}
@@ -1794,6 +2627,34 @@ packages:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
 
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  object-keys@1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
+
+  object.assign@4.1.7:
+    resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
+    engines: {node: '>= 0.4'}
+
+  object.entries@1.1.9:
+    resolution: {integrity: sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==}
+    engines: {node: '>= 0.4'}
+
+  object.fromentries@2.0.8:
+    resolution: {integrity: sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==}
+    engines: {node: '>= 0.4'}
+
+  object.groupby@1.0.3:
+    resolution: {integrity: sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==}
+    engines: {node: '>= 0.4'}
+
+  object.values@1.2.1:
+    resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
+    engines: {node: '>= 0.4'}
+
   obuf@1.1.2:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
 
@@ -1807,14 +2668,38 @@ packages:
   openseadragon@5.0.1:
     resolution: {integrity: sha512-a/hjouW9i3UfWxRADVYN2MyRhXMGnE7x9VVL7/4jXCcDLFyO4UM5o4RStYtqa5BfaHw/wMNAaD2WbxQF8f1pJg==}
 
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  own-keys@1.0.1:
+    resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
+    engines: {node: '>= 0.4'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
   pako@0.2.9:
     resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
 
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
   parse-css-color@0.2.1:
     resolution: {integrity: sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -1879,6 +2764,10 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
+  picomatch@4.0.2:
+    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
@@ -1889,6 +2778,10 @@ packages:
 
   poly2tri@1.5.0:
     resolution: {integrity: sha512-5yACqznqRrlFA9RhdWyD2blNPVhlB3qK+iRYJCfHtJGINb+XNBgKTw+pJOsJZ+oaGxFsIyFmOVapuREHnRhXPg==}
+
+  possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
+    engines: {node: '>= 0.4'}
 
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
@@ -1978,6 +2871,10 @@ packages:
   preact@10.26.5:
     resolution: {integrity: sha512-fmpDkgfGU6JYux9teDWLhj9mKN55tyepwYbxHgQuIxbWQzgFg5vk7Mrrtfx7xRxq798ynkY4DDDxZr235Kk+4w==}
 
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
   pretty-format@3.8.0:
     resolution: {integrity: sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==}
 
@@ -1987,6 +2884,10 @@ packages:
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -2089,12 +2990,31 @@ packages:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  reflect.getprototypeof@1.0.10:
+    resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
+    engines: {node: '>= 0.4'}
+
   regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
+
+  regexp.prototype.flags@1.5.4:
+    resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
+    engines: {node: '>= 0.4'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
   resolve@1.22.10:
     resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
     engines: {node: '>= 0.4'}
+    hasBin: true
+
+  resolve@2.0.0-next.5:
+    resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
     hasBin: true
 
   reusify@1.1.0:
@@ -2119,6 +3039,18 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  safe-array-concat@1.1.3:
+    resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
+    engines: {node: '>=0.4'}
+
+  safe-push-apply@1.0.0:
+    resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
+    engines: {node: '>= 0.4'}
+
+  safe-regex-test@1.1.0:
+    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
+    engines: {node: '>= 0.4'}
+
   satori@0.12.2:
     resolution: {integrity: sha512-3C/laIeE6UUe9A+iQ0A48ywPVCCMKCNSTU5Os101Vhgsjd3AAxGNjyq0uAA8kulMPK5n0csn8JlxPN9riXEjLA==}
     engines: {node: '>=16'}
@@ -2126,10 +3058,26 @@ packages:
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
   semver@7.7.1:
     resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+
+  set-function-name@2.0.2:
+    resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
+    engines: {node: '>= 0.4'}
+
+  set-proto@1.0.0:
+    resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
+    engines: {node: '>= 0.4'}
 
   sharp@0.33.5:
     resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
@@ -2142,6 +3090,22 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.0:
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
@@ -2164,6 +3128,13 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  stable-hash@0.0.5:
+    resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
+
+  stop-iteration-iterator@1.1.0:
+    resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
+    engines: {node: '>= 0.4'}
+
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
@@ -2179,6 +3150,29 @@ packages:
   string.prototype.codepointat@0.2.1:
     resolution: {integrity: sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==}
 
+  string.prototype.includes@2.0.1:
+    resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.matchall@4.0.12:
+    resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.repeat@1.0.0:
+    resolution: {integrity: sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==}
+
+  string.prototype.trim@1.2.10:
+    resolution: {integrity: sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trimend@1.0.9:
+    resolution: {integrity: sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trimstart@1.0.8:
+    resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
+    engines: {node: '>= 0.4'}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -2186,6 +3180,14 @@ packages:
   strip-ansi@7.1.0:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
     engines: {node: '>=12'}
+
+  strip-bom@3.0.0:
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
+    engines: {node: '>=4'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -2204,6 +3206,10 @@ packages:
     resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
 
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
@@ -2238,12 +3244,25 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinyglobby@0.2.14:
+    resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
+    engines: {node: '>=12.0.0'}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  ts-api-utils@2.1.0:
+    resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsconfig-paths@3.15.0:
+    resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -2254,10 +3273,34 @@ packages:
   two-sum@1.0.0:
     resolution: {integrity: sha512-phP48e8AawgsNUjEY2WvoIWqdie8PoiDZGxTDv70LDr01uX5wLEQbOgSP7Z/B6+SW5oLtbe8qaYX2fKJs3CGTw==}
 
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  typed-array-buffer@1.0.3:
+    resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-byte-length@1.0.3:
+    resolution: {integrity: sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-byte-offset@1.0.4:
+    resolution: {integrity: sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-length@1.0.7:
+    resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
+    engines: {node: '>= 0.4'}
+
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  unbox-primitive@1.1.0:
+    resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
+    engines: {node: '>= 0.4'}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -2265,11 +3308,17 @@ packages:
   unicode-trie@2.0.0:
     resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
 
+  unrs-resolver@1.9.2:
+    resolution: {integrity: sha512-VUyWiTNQD7itdiMuJy+EuLEErLj3uwX/EpHQF8EOf33Dq3Ju6VW1GXm+swk6+1h7a49uv9fKZ+dft9jU7esdLA==}
+
   update-browserslist-db@1.1.3:
     resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
@@ -2315,10 +3364,30 @@ packages:
   victory-vendor@36.9.2:
     resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
 
+  which-boxed-primitive@1.1.1:
+    resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
+    engines: {node: '>= 0.4'}
+
+  which-builtin-type@1.2.1:
+    resolution: {integrity: sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==}
+    engines: {node: '>= 0.4'}
+
+  which-collection@1.0.2:
+    resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
+    engines: {node: '>= 0.4'}
+
+  which-typed-array@1.1.19:
+    resolution: {integrity: sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==}
+    engines: {node: '>= 0.4'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
     hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -2339,6 +3408,10 @@ packages:
     resolution: {integrity: sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==}
     engines: {node: '>= 14'}
     hasBin: true
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
 
   yoga-wasm-web@0.3.3:
     resolution: {integrity: sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA==}
@@ -2418,10 +3491,69 @@ snapshots:
     dependencies:
       regenerator-runtime: 0.14.1
 
+  '@emnapi/core@1.4.3':
+    dependencies:
+      '@emnapi/wasi-threads': 1.0.2
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.4.3':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@emnapi/wasi-threads@1.0.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@eslint-community/eslint-utils@4.7.0(eslint@9.30.1(jiti@1.21.7))':
+    dependencies:
+      eslint: 9.30.1(jiti@1.21.7)
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.1': {}
+
+  '@eslint/config-array@0.21.0':
+    dependencies:
+      '@eslint/object-schema': 2.1.6
+      debug: 4.4.1
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.3.0': {}
+
+  '@eslint/core@0.14.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/core@0.15.1':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/eslintrc@3.3.1':
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.4.1
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@9.30.1': {}
+
+  '@eslint/object-schema@2.1.6': {}
+
+  '@eslint/plugin-kit@0.3.3':
+    dependencies:
+      '@eslint/core': 0.15.1
+      levn: 0.4.1
 
   '@floating-ui/core@1.6.9':
     dependencies:
@@ -2443,6 +3575,19 @@ snapshots:
   '@hookform/resolvers@3.10.0(react-hook-form@7.56.1(react@18.3.1))':
     dependencies:
       react-hook-form: 7.56.1(react@18.3.1)
+
+  '@humanfs/core@0.19.1': {}
+
+  '@humanfs/node@0.16.6':
+    dependencies:
+      '@humanfs/core': 0.19.1
+      '@humanwhocodes/retry': 0.3.1
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.3.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
 
   '@img/sharp-darwin-arm64@0.33.5':
     optionalDependencies:
@@ -2545,7 +3690,18 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  '@napi-rs/wasm-runtime@0.2.11':
+    dependencies:
+      '@emnapi/core': 1.4.3
+      '@emnapi/runtime': 1.4.3
+      '@tybys/wasm-util': 0.9.0
+    optional: true
+
   '@next/env@15.2.4': {}
+
+  '@next/eslint-plugin-next@15.3.4':
+    dependencies:
+      fast-glob: 3.3.1
 
   '@next/swc-darwin-arm64@15.2.4':
     optional: true
@@ -2582,6 +3738,8 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
+
+  '@nolyfill/is-core-module@1.0.39': {}
 
   '@panva/hkdf@1.2.1': {}
 
@@ -3265,6 +4423,10 @@ snapshots:
 
   '@resvg/resvg-wasm@2.4.0': {}
 
+  '@rtsao/scc@1.1.0': {}
+
+  '@rushstack/eslint-patch@1.12.0': {}
+
   '@shuding/opentype.js@1.4.0-beta.0':
     dependencies:
       fflate: 0.7.4
@@ -3309,6 +4471,11 @@ snapshots:
       '@turf/distance': 6.5.0
       '@turf/helpers': 6.5.0
 
+  '@tybys/wasm-util@0.9.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@types/d3-array@3.2.1': {}
 
   '@types/d3-color@3.1.3': {}
@@ -3333,7 +4500,13 @@ snapshots:
 
   '@types/d3-timer@3.0.2': {}
 
+  '@types/estree@1.0.8': {}
+
   '@types/geojson@7946.0.16': {}
+
+  '@types/json-schema@7.0.15': {}
+
+  '@types/json5@0.0.29': {}
 
   '@types/leaflet@1.9.17':
     dependencies:
@@ -3359,11 +4532,175 @@ snapshots:
     dependencies:
       csstype: 3.1.3
 
+  '@typescript-eslint/eslint-plugin@8.35.1(@typescript-eslint/parser@8.35.1(eslint@9.30.1(jiti@1.21.7))(typescript@5.8.3))(eslint@9.30.1(jiti@1.21.7))(typescript@5.8.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+      '@typescript-eslint/parser': 8.35.1(eslint@9.30.1(jiti@1.21.7))(typescript@5.8.3)
+      '@typescript-eslint/scope-manager': 8.35.1
+      '@typescript-eslint/type-utils': 8.35.1(eslint@9.30.1(jiti@1.21.7))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.35.1(eslint@9.30.1(jiti@1.21.7))(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 8.35.1
+      eslint: 9.30.1(jiti@1.21.7)
+      graphemer: 1.4.0
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.1.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.35.1(eslint@9.30.1(jiti@1.21.7))(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.35.1
+      '@typescript-eslint/types': 8.35.1
+      '@typescript-eslint/typescript-estree': 8.35.1(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 8.35.1
+      debug: 4.4.1
+      eslint: 9.30.1(jiti@1.21.7)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.35.1(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.35.1(typescript@5.8.3)
+      '@typescript-eslint/types': 8.35.1
+      debug: 4.4.1
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.35.1':
+    dependencies:
+      '@typescript-eslint/types': 8.35.1
+      '@typescript-eslint/visitor-keys': 8.35.1
+
+  '@typescript-eslint/tsconfig-utils@8.35.1(typescript@5.8.3)':
+    dependencies:
+      typescript: 5.8.3
+
+  '@typescript-eslint/type-utils@8.35.1(eslint@9.30.1(jiti@1.21.7))(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/typescript-estree': 8.35.1(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.35.1(eslint@9.30.1(jiti@1.21.7))(typescript@5.8.3)
+      debug: 4.4.1
+      eslint: 9.30.1(jiti@1.21.7)
+      ts-api-utils: 2.1.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.35.1': {}
+
+  '@typescript-eslint/typescript-estree@8.35.1(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.35.1(typescript@5.8.3)
+      '@typescript-eslint/tsconfig-utils': 8.35.1(typescript@5.8.3)
+      '@typescript-eslint/types': 8.35.1
+      '@typescript-eslint/visitor-keys': 8.35.1
+      debug: 4.4.1
+      fast-glob: 3.3.3
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.1
+      ts-api-utils: 2.1.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.35.1(eslint@9.30.1(jiti@1.21.7))(typescript@5.8.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.30.1(jiti@1.21.7))
+      '@typescript-eslint/scope-manager': 8.35.1
+      '@typescript-eslint/types': 8.35.1
+      '@typescript-eslint/typescript-estree': 8.35.1(typescript@5.8.3)
+      eslint: 9.30.1(jiti@1.21.7)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.35.1':
+    dependencies:
+      '@typescript-eslint/types': 8.35.1
+      eslint-visitor-keys: 4.2.1
+
+  '@unrs/resolver-binding-android-arm-eabi@1.9.2':
+    optional: true
+
+  '@unrs/resolver-binding-android-arm64@1.9.2':
+    optional: true
+
+  '@unrs/resolver-binding-darwin-arm64@1.9.2':
+    optional: true
+
+  '@unrs/resolver-binding-darwin-x64@1.9.2':
+    optional: true
+
+  '@unrs/resolver-binding-freebsd-x64@1.9.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm-gnueabihf@1.9.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm-musleabihf@1.9.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm64-gnu@1.9.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm64-musl@1.9.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-ppc64-gnu@1.9.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-riscv64-gnu@1.9.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-riscv64-musl@1.9.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-s390x-gnu@1.9.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-x64-gnu@1.9.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-x64-musl@1.9.2':
+    optional: true
+
+  '@unrs/resolver-binding-wasm32-wasi@1.9.2':
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.11
+    optional: true
+
+  '@unrs/resolver-binding-win32-arm64-msvc@1.9.2':
+    optional: true
+
+  '@unrs/resolver-binding-win32-ia32-msvc@1.9.2':
+    optional: true
+
+  '@unrs/resolver-binding-win32-x64-msvc@1.9.2':
+    optional: true
+
   '@vercel/og@0.6.8':
     dependencies:
       '@resvg/resvg-wasm': 2.4.0
       satori: 0.12.2
       yoga-wasm-web: 0.3.3
+
+  acorn-jsx@5.3.2(acorn@8.15.0):
+    dependencies:
+      acorn: 8.15.0
+
+  acorn@8.15.0: {}
+
+  ajv@6.12.6:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
 
   ansi-regex@5.0.1: {}
 
@@ -3384,9 +4721,84 @@ snapshots:
 
   arg@5.0.2: {}
 
+  argparse@2.0.1: {}
+
   aria-hidden@1.2.4:
     dependencies:
       tslib: 2.8.1
+
+  aria-query@5.3.2: {}
+
+  array-buffer-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      is-array-buffer: 3.0.5
+
+  array-includes@3.1.9:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.0
+      es-object-atoms: 1.1.1
+      get-intrinsic: 1.3.0
+      is-string: 1.1.1
+      math-intrinsics: 1.1.0
+
+  array.prototype.findlast@1.2.5:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.24.0
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      es-shim-unscopables: 1.1.0
+
+  array.prototype.findlastindex@1.2.6:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.0
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      es-shim-unscopables: 1.1.0
+
+  array.prototype.flat@1.3.3:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.24.0
+      es-shim-unscopables: 1.1.0
+
+  array.prototype.flatmap@1.3.3:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.24.0
+      es-shim-unscopables: 1.1.0
+
+  array.prototype.tosorted@1.1.4:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.24.0
+      es-errors: 1.3.0
+      es-shim-unscopables: 1.1.0
+
+  arraybuffer.prototype.slice@1.0.4:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.24.0
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      is-array-buffer: 3.0.5
+
+  ast-types-flow@0.0.8: {}
+
+  async-function@1.0.0: {}
 
   autoprefixer@10.4.21(postcss@8.5.3):
     dependencies:
@@ -3398,11 +4810,24 @@ snapshots:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
+  available-typed-arrays@1.0.7:
+    dependencies:
+      possible-typed-array-names: 1.1.0
+
+  axe-core@4.10.3: {}
+
+  axobject-query@4.1.0: {}
+
   balanced-match@1.0.2: {}
 
   base64-js@0.0.8: {}
 
   binary-extensions@2.3.0: {}
+
+  brace-expansion@1.1.12:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
 
   brace-expansion@2.0.1:
     dependencies:
@@ -3423,11 +4848,35 @@ snapshots:
     dependencies:
       streamsearch: 1.1.0
 
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bind@1.0.8:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
+  callsites@3.1.0: {}
+
   camelcase-css@2.0.1: {}
 
   camelize@1.0.1: {}
 
   caniuse-lite@1.0.30001715: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
 
   chokidar@3.6.0:
     dependencies:
@@ -3482,6 +4931,8 @@ snapshots:
   comlink@4.4.2: {}
 
   commander@4.1.1: {}
+
+  concat-map@0.0.1: {}
 
   cookie@0.7.2: {}
 
@@ -3547,9 +4998,51 @@ snapshots:
 
   d3-timer@3.0.1: {}
 
+  damerau-levenshtein@1.0.8: {}
+
+  data-view-buffer@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  data-view-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  data-view-byte-offset@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
   date-fns@4.1.0: {}
 
+  debug@3.2.7:
+    dependencies:
+      ms: 2.1.3
+
+  debug@4.4.1:
+    dependencies:
+      ms: 2.1.3
+
   decimal.js-light@2.5.1: {}
+
+  deep-is@0.1.4: {}
+
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  define-properties@1.2.1:
+    dependencies:
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
+      object-keys: 1.1.1
 
   detect-libc@2.0.4:
     optional: true
@@ -3560,6 +5053,10 @@ snapshots:
 
   dlv@1.1.3: {}
 
+  doctrine@2.1.0:
+    dependencies:
+      esutils: 2.0.3
+
   dom-helpers@5.2.1:
     dependencies:
       '@babel/runtime': 7.27.0
@@ -3569,6 +5066,12 @@ snapshots:
     optionalDependencies:
       '@types/pg': 8.11.14
       pg: 8.15.6
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
 
   eastasianwidth@0.2.0: {}
 
@@ -3592,13 +5095,323 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
+  es-abstract@1.24.0:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      arraybuffer.prototype.slice: 1.0.4
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      data-view-buffer: 1.0.2
+      data-view-byte-length: 1.0.2
+      data-view-byte-offset: 1.0.1
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      es-set-tostringtag: 2.1.0
+      es-to-primitive: 1.3.0
+      function.prototype.name: 1.1.8
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      get-symbol-description: 1.1.0
+      globalthis: 1.0.4
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+      has-proto: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      internal-slot: 1.1.0
+      is-array-buffer: 3.0.5
+      is-callable: 1.2.7
+      is-data-view: 1.0.2
+      is-negative-zero: 2.0.3
+      is-regex: 1.2.1
+      is-set: 2.0.3
+      is-shared-array-buffer: 1.0.4
+      is-string: 1.1.1
+      is-typed-array: 1.1.15
+      is-weakref: 1.1.1
+      math-intrinsics: 1.1.0
+      object-inspect: 1.13.4
+      object-keys: 1.1.1
+      object.assign: 4.1.7
+      own-keys: 1.0.1
+      regexp.prototype.flags: 1.5.4
+      safe-array-concat: 1.1.3
+      safe-push-apply: 1.0.0
+      safe-regex-test: 1.1.0
+      set-proto: 1.0.0
+      stop-iteration-iterator: 1.1.0
+      string.prototype.trim: 1.2.10
+      string.prototype.trimend: 1.0.9
+      string.prototype.trimstart: 1.0.8
+      typed-array-buffer: 1.0.3
+      typed-array-byte-length: 1.0.3
+      typed-array-byte-offset: 1.0.4
+      typed-array-length: 1.0.7
+      unbox-primitive: 1.1.0
+      which-typed-array: 1.1.19
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-iterator-helpers@1.2.1:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.0
+      es-errors: 1.3.0
+      es-set-tostringtag: 2.1.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      globalthis: 1.0.4
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+      has-proto: 1.2.0
+      has-symbols: 1.1.0
+      internal-slot: 1.1.0
+      iterator.prototype: 1.1.5
+      safe-array-concat: 1.1.3
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+
+  es-shim-unscopables@1.1.0:
+    dependencies:
+      hasown: 2.0.2
+
+  es-to-primitive@1.3.0:
+    dependencies:
+      is-callable: 1.2.7
+      is-date-object: 1.1.0
+      is-symbol: 1.1.1
+
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
 
+  escape-string-regexp@4.0.0: {}
+
+  eslint-config-next@15.3.4(eslint@9.30.1(jiti@1.21.7))(typescript@5.8.3):
+    dependencies:
+      '@next/eslint-plugin-next': 15.3.4
+      '@rushstack/eslint-patch': 1.12.0
+      '@typescript-eslint/eslint-plugin': 8.35.1(@typescript-eslint/parser@8.35.1(eslint@9.30.1(jiti@1.21.7))(typescript@5.8.3))(eslint@9.30.1(jiti@1.21.7))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.35.1(eslint@9.30.1(jiti@1.21.7))(typescript@5.8.3)
+      eslint: 9.30.1(jiti@1.21.7)
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.30.1(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.35.1(eslint@9.30.1(jiti@1.21.7))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.30.1(jiti@1.21.7))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.30.1(jiti@1.21.7))
+      eslint-plugin-react: 7.37.5(eslint@9.30.1(jiti@1.21.7))
+      eslint-plugin-react-hooks: 5.2.0(eslint@9.30.1(jiti@1.21.7))
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - eslint-import-resolver-webpack
+      - eslint-plugin-import-x
+      - supports-color
+
+  eslint-import-resolver-node@0.3.9:
+    dependencies:
+      debug: 3.2.7
+      is-core-module: 2.16.1
+      resolve: 1.22.10
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.30.1(jiti@1.21.7)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.1
+      eslint: 9.30.1(jiti@1.21.7)
+      get-tsconfig: 4.10.1
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.14
+      unrs-resolver: 1.9.2
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.35.1(eslint@9.30.1(jiti@1.21.7))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.30.1(jiti@1.21.7))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.35.1(eslint@9.30.1(jiti@1.21.7))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.30.1(jiti@1.21.7)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.35.1(eslint@9.30.1(jiti@1.21.7))(typescript@5.8.3)
+      eslint: 9.30.1(jiti@1.21.7)
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.30.1(jiti@1.21.7))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.35.1(eslint@9.30.1(jiti@1.21.7))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.30.1(jiti@1.21.7)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.30.1(jiti@1.21.7)
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.35.1(eslint@9.30.1(jiti@1.21.7))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.30.1(jiti@1.21.7))
+      hasown: 2.0.2
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.35.1(eslint@9.30.1(jiti@1.21.7))(typescript@5.8.3)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.30.1(jiti@1.21.7)):
+    dependencies:
+      aria-query: 5.3.2
+      array-includes: 3.1.9
+      array.prototype.flatmap: 1.3.3
+      ast-types-flow: 0.0.8
+      axe-core: 4.10.3
+      axobject-query: 4.1.0
+      damerau-levenshtein: 1.0.8
+      emoji-regex: 9.2.2
+      eslint: 9.30.1(jiti@1.21.7)
+      hasown: 2.0.2
+      jsx-ast-utils: 3.3.5
+      language-tags: 1.0.9
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      safe-regex-test: 1.1.0
+      string.prototype.includes: 2.0.1
+
+  eslint-plugin-react-hooks@5.2.0(eslint@9.30.1(jiti@1.21.7)):
+    dependencies:
+      eslint: 9.30.1(jiti@1.21.7)
+
+  eslint-plugin-react@7.37.5(eslint@9.30.1(jiti@1.21.7)):
+    dependencies:
+      array-includes: 3.1.9
+      array.prototype.findlast: 1.2.5
+      array.prototype.flatmap: 1.3.3
+      array.prototype.tosorted: 1.1.4
+      doctrine: 2.1.0
+      es-iterator-helpers: 1.2.1
+      eslint: 9.30.1(jiti@1.21.7)
+      estraverse: 5.3.0
+      hasown: 2.0.2
+      jsx-ast-utils: 3.3.5
+      minimatch: 3.1.2
+      object.entries: 1.1.9
+      object.fromentries: 2.0.8
+      object.values: 1.2.1
+      prop-types: 15.8.1
+      resolve: 2.0.0-next.5
+      semver: 6.3.1
+      string.prototype.matchall: 4.0.12
+      string.prototype.repeat: 1.0.0
+
+  eslint-scope@8.4.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.1: {}
+
+  eslint@9.30.1(jiti@1.21.7):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.30.1(jiti@1.21.7))
+      '@eslint-community/regexpp': 4.12.1
+      '@eslint/config-array': 0.21.0
+      '@eslint/config-helpers': 0.3.0
+      '@eslint/core': 0.14.0
+      '@eslint/eslintrc': 3.3.1
+      '@eslint/js': 9.30.1
+      '@eslint/plugin-kit': 0.3.3
+      '@humanfs/node': 0.16.6
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.1
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.6.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    optionalDependencies:
+      jiti: 1.21.7
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
+      eslint-visitor-keys: 4.2.1
+
+  esquery@1.6.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
+  esutils@2.0.3: {}
+
   eventemitter3@4.0.7: {}
 
+  fast-deep-equal@3.1.3: {}
+
   fast-equals@5.2.2: {}
+
+  fast-glob@3.3.1:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
 
   fast-glob@3.3.3:
     dependencies:
@@ -3608,15 +5421,43 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
 
+  fdir@6.4.6(picomatch@4.0.2):
+    optionalDependencies:
+      picomatch: 4.0.2
+
   fflate@0.7.4: {}
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
 
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.3.3
+      keyv: 4.5.4
+
+  flatted@3.3.3: {}
+
+  for-each@0.3.5:
+    dependencies:
+      is-callable: 1.2.7
 
   foreground-child@3.3.1:
     dependencies:
@@ -3632,7 +5473,46 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  function.prototype.name@1.1.8:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      functions-have-names: 1.2.3
+      hasown: 2.0.2
+      is-callable: 1.2.7
+
+  functions-have-names@1.2.3: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
   get-nonce@1.0.1: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  get-symbol-description@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+
+  get-tsconfig@4.10.1:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   glob-parent@5.1.2:
     dependencies:
@@ -3651,11 +5531,51 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
+  globals@14.0.0: {}
+
+  globalthis@1.0.4:
+    dependencies:
+      define-properties: 1.2.1
+      gopd: 1.2.0
+
+  gopd@1.2.0: {}
+
+  graphemer@1.4.0: {}
+
+  has-bigints@1.1.0: {}
+
+  has-flag@4.0.0: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+
+  has-proto@1.2.0:
+    dependencies:
+      dunder-proto: 1.0.1
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
 
   hex-rgb@4.3.0: {}
+
+  ignore@5.3.2: {}
+
+  ignore@7.0.5: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  imurmurhash@0.1.4: {}
 
   inherits@2.0.3: {}
 
@@ -3664,32 +5584,148 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  internal-slot@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      hasown: 2.0.2
+      side-channel: 1.1.0
+
   internmap@2.0.3: {}
 
   is-any-array@2.0.1: {}
 
+  is-array-buffer@3.0.5:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
   is-arrayish@0.3.2:
     optional: true
+
+  is-async-function@2.1.1:
+    dependencies:
+      async-function: 1.0.0
+      call-bound: 1.0.4
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
+
+  is-bigint@1.1.0:
+    dependencies:
+      has-bigints: 1.1.0
 
   is-binary-path@2.1.0:
     dependencies:
       binary-extensions: 2.3.0
 
+  is-boolean-object@1.2.2:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-bun-module@2.0.0:
+    dependencies:
+      semver: 7.7.1
+
+  is-callable@1.2.7: {}
+
   is-core-module@2.16.1:
     dependencies:
       hasown: 2.0.2
 
+  is-data-view@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+      is-typed-array: 1.1.15
+
+  is-date-object@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
   is-extglob@2.1.1: {}
 
+  is-finalizationregistry@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+
   is-fullwidth-code-point@3.0.0: {}
+
+  is-generator-function@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
 
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
 
+  is-map@2.0.3: {}
+
+  is-negative-zero@2.0.3: {}
+
+  is-number-object@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
   is-number@7.0.0: {}
 
+  is-regex@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+
+  is-set@2.0.3: {}
+
+  is-shared-array-buffer@1.0.4:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-string@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-symbol@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-symbols: 1.1.0
+      safe-regex-test: 1.1.0
+
+  is-typed-array@1.1.15:
+    dependencies:
+      which-typed-array: 1.1.19
+
+  is-weakmap@2.0.2: {}
+
+  is-weakref@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-weakset@2.0.4:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
+  isarray@2.0.5: {}
+
   isexe@2.0.0: {}
+
+  iterator.prototype@1.1.5:
+    dependencies:
+      define-data-property: 1.1.4
+      es-object-atoms: 1.1.1
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      has-symbols: 1.1.0
+      set-function-name: 2.0.2
 
   jackspeak@3.4.3:
     dependencies:
@@ -3703,7 +5739,43 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-yaml@4.1.0:
+    dependencies:
+      argparse: 2.0.1
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json5@1.0.2:
+    dependencies:
+      minimist: 1.2.8
+
+  jsx-ast-utils@3.3.5:
+    dependencies:
+      array-includes: 3.1.9
+      array.prototype.flat: 1.3.3
+      object.assign: 4.1.7
+      object.values: 1.2.1
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  language-subtag-registry@0.3.23: {}
+
+  language-tags@1.0.9:
+    dependencies:
+      language-subtag-registry: 0.3.23
+
   leaflet@1.9.4: {}
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
 
   lilconfig@3.1.3: {}
 
@@ -3714,7 +5786,13 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
   lodash-es@4.17.21: {}
+
+  lodash.merge@4.6.2: {}
 
   lodash@4.17.21: {}
 
@@ -3732,6 +5810,8 @@ snapshots:
     dependencies:
       react: 18.3.1
 
+  math-intrinsics@1.1.0: {}
+
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
@@ -3739,9 +5819,15 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  minimatch@3.1.2:
+    dependencies:
+      brace-expansion: 1.1.12
+
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.1
+
+  minimist@1.2.8: {}
 
   minipass@7.1.2: {}
 
@@ -3766,6 +5852,8 @@ snapshots:
 
   monaco-editor@0.52.2: {}
 
+  ms@2.1.3: {}
+
   mz@2.7.0:
     dependencies:
       any-promise: 1.3.0
@@ -3773,6 +5861,10 @@ snapshots:
       thenify-all: 1.6.0
 
   nanoid@3.3.11: {}
+
+  napi-postinstall@0.2.5: {}
+
+  natural-compare@1.4.0: {}
 
   next-auth@4.24.11(next@15.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -3833,6 +5925,46 @@ snapshots:
 
   object-hash@3.0.0: {}
 
+  object-inspect@1.13.4: {}
+
+  object-keys@1.1.1: {}
+
+  object.assign@4.1.7:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+      has-symbols: 1.1.0
+      object-keys: 1.1.1
+
+  object.entries@1.1.9:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+
+  object.fromentries@2.0.8:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.24.0
+      es-object-atoms: 1.1.1
+
+  object.groupby@1.0.3:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.24.0
+
+  object.values@1.2.1:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+
   obuf@1.1.2: {}
 
   oidc-token-hash@5.1.0: {}
@@ -3846,14 +5978,43 @@ snapshots:
 
   openseadragon@5.0.1: {}
 
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  own-keys@1.0.1:
+    dependencies:
+      get-intrinsic: 1.3.0
+      object-keys: 1.1.1
+      safe-push-apply: 1.0.0
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
   package-json-from-dist@1.0.1: {}
 
   pako@0.2.9: {}
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
 
   parse-css-color@0.2.1:
     dependencies:
       color-name: 1.1.4
       hex-rgb: 4.3.0
+
+  path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
 
@@ -3920,11 +6081,15 @@ snapshots:
 
   picomatch@2.3.1: {}
 
+  picomatch@4.0.2: {}
+
   pify@2.3.0: {}
 
   pirates@4.0.7: {}
 
   poly2tri@1.5.0: {}
+
+  possible-typed-array-names@1.1.0: {}
 
   postcss-import@15.1.0(postcss@8.5.3):
     dependencies:
@@ -3998,6 +6163,8 @@ snapshots:
 
   preact@10.26.5: {}
 
+  prelude-ls@1.2.1: {}
+
   pretty-format@3.8.0: {}
 
   process@0.11.10: {}
@@ -4007,6 +6174,8 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
 
@@ -4113,9 +6282,39 @@ snapshots:
       tiny-invariant: 1.3.3
       victory-vendor: 36.9.2
 
+  reflect.getprototypeof@1.0.10:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.24.0
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      which-builtin-type: 1.2.1
+
   regenerator-runtime@0.14.1: {}
 
+  regexp.prototype.flags@1.5.4:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-errors: 1.3.0
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      set-function-name: 2.0.2
+
+  resolve-from@4.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
   resolve@1.22.10:
+    dependencies:
+      is-core-module: 2.16.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
+  resolve@2.0.0-next.5:
     dependencies:
       is-core-module: 2.16.1
       path-parse: 1.0.7
@@ -4147,6 +6346,25 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  safe-array-concat@1.1.3:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+      has-symbols: 1.1.0
+      isarray: 2.0.5
+
+  safe-push-apply@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      isarray: 2.0.5
+
+  safe-regex-test@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-regex: 1.2.1
+
   satori@0.12.2:
     dependencies:
       '@shuding/opentype.js': 1.4.0-beta.0
@@ -4165,8 +6383,31 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  semver@7.7.1:
-    optional: true
+  semver@6.3.1: {}
+
+  semver@7.7.1: {}
+
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+
+  set-function-name@2.0.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      functions-have-names: 1.2.3
+      has-property-descriptors: 1.0.2
+
+  set-proto@1.0.0:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
 
   sharp@0.33.5:
     dependencies:
@@ -4201,6 +6442,34 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   signal-exit@4.1.0: {}
 
   simple-swizzle@0.2.2:
@@ -4216,6 +6485,13 @@ snapshots:
   source-map-js@1.2.1: {}
 
   split2@4.2.0: {}
+
+  stable-hash@0.0.5: {}
+
+  stop-iteration-iterator@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      internal-slot: 1.1.0
 
   streamsearch@1.1.0: {}
 
@@ -4233,6 +6509,56 @@ snapshots:
 
   string.prototype.codepointat@0.2.1: {}
 
+  string.prototype.includes@2.0.1:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.24.0
+
+  string.prototype.matchall@4.0.12:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.0
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      internal-slot: 1.1.0
+      regexp.prototype.flags: 1.5.4
+      set-function-name: 2.0.2
+      side-channel: 1.1.0
+
+  string.prototype.repeat@1.0.0:
+    dependencies:
+      define-properties: 1.2.1
+      es-abstract: 1.24.0
+
+  string.prototype.trim@1.2.10:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      define-data-property: 1.1.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.0
+      es-object-atoms: 1.1.1
+      has-property-descriptors: 1.0.2
+
+  string.prototype.trimend@1.0.9:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+
+  string.prototype.trimstart@1.0.8:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -4240,6 +6566,10 @@ snapshots:
   strip-ansi@7.1.0:
     dependencies:
       ansi-regex: 6.1.0
+
+  strip-bom@3.0.0: {}
+
+  strip-json-comments@3.1.1: {}
 
   styled-jsx@5.1.6(react@18.3.1):
     dependencies:
@@ -4255,6 +6585,10 @@ snapshots:
       mz: 2.7.0
       pirates: 4.0.7
       ts-interface-checker: 0.1.13
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
@@ -4305,11 +6639,27 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinyglobby@0.2.14:
+    dependencies:
+      fdir: 6.4.6(picomatch@4.0.2)
+      picomatch: 4.0.2
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
+  ts-api-utils@2.1.0(typescript@5.8.3):
+    dependencies:
+      typescript: 5.8.3
+
   ts-interface-checker@0.1.13: {}
+
+  tsconfig-paths@3.15.0:
+    dependencies:
+      '@types/json5': 0.0.29
+      json5: 1.0.2
+      minimist: 1.2.8
+      strip-bom: 3.0.0
 
   tslib@2.8.1: {}
 
@@ -4317,7 +6667,51 @@ snapshots:
 
   two-sum@1.0.0: {}
 
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
+  typed-array-buffer@1.0.3:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-typed-array: 1.1.15
+
+  typed-array-byte-length@1.0.3:
+    dependencies:
+      call-bind: 1.0.8
+      for-each: 0.3.5
+      gopd: 1.2.0
+      has-proto: 1.2.0
+      is-typed-array: 1.1.15
+
+  typed-array-byte-offset@1.0.4:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.8
+      for-each: 0.3.5
+      gopd: 1.2.0
+      has-proto: 1.2.0
+      is-typed-array: 1.1.15
+      reflect.getprototypeof: 1.0.10
+
+  typed-array-length@1.0.7:
+    dependencies:
+      call-bind: 1.0.8
+      for-each: 0.3.5
+      gopd: 1.2.0
+      is-typed-array: 1.1.15
+      possible-typed-array-names: 1.1.0
+      reflect.getprototypeof: 1.0.10
+
   typescript@5.8.3: {}
+
+  unbox-primitive@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-bigints: 1.1.0
+      has-symbols: 1.1.0
+      which-boxed-primitive: 1.1.1
 
   undici-types@6.21.0: {}
 
@@ -4326,11 +6720,39 @@ snapshots:
       pako: 0.2.9
       tiny-inflate: 1.0.3
 
+  unrs-resolver@1.9.2:
+    dependencies:
+      napi-postinstall: 0.2.5
+    optionalDependencies:
+      '@unrs/resolver-binding-android-arm-eabi': 1.9.2
+      '@unrs/resolver-binding-android-arm64': 1.9.2
+      '@unrs/resolver-binding-darwin-arm64': 1.9.2
+      '@unrs/resolver-binding-darwin-x64': 1.9.2
+      '@unrs/resolver-binding-freebsd-x64': 1.9.2
+      '@unrs/resolver-binding-linux-arm-gnueabihf': 1.9.2
+      '@unrs/resolver-binding-linux-arm-musleabihf': 1.9.2
+      '@unrs/resolver-binding-linux-arm64-gnu': 1.9.2
+      '@unrs/resolver-binding-linux-arm64-musl': 1.9.2
+      '@unrs/resolver-binding-linux-ppc64-gnu': 1.9.2
+      '@unrs/resolver-binding-linux-riscv64-gnu': 1.9.2
+      '@unrs/resolver-binding-linux-riscv64-musl': 1.9.2
+      '@unrs/resolver-binding-linux-s390x-gnu': 1.9.2
+      '@unrs/resolver-binding-linux-x64-gnu': 1.9.2
+      '@unrs/resolver-binding-linux-x64-musl': 1.9.2
+      '@unrs/resolver-binding-wasm32-wasi': 1.9.2
+      '@unrs/resolver-binding-win32-arm64-msvc': 1.9.2
+      '@unrs/resolver-binding-win32-ia32-msvc': 1.9.2
+      '@unrs/resolver-binding-win32-x64-msvc': 1.9.2
+
   update-browserslist-db@1.1.3(browserslist@4.24.4):
     dependencies:
       browserslist: 4.24.4
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
 
   use-callback-ref@1.3.3(@types/react@19.1.2)(react@18.3.1):
     dependencies:
@@ -4385,9 +6807,52 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  which-boxed-primitive@1.1.1:
+    dependencies:
+      is-bigint: 1.1.0
+      is-boolean-object: 1.2.2
+      is-number-object: 1.1.1
+      is-string: 1.1.1
+      is-symbol: 1.1.1
+
+  which-builtin-type@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      function.prototype.name: 1.1.8
+      has-tostringtag: 1.0.2
+      is-async-function: 2.1.1
+      is-date-object: 1.1.0
+      is-finalizationregistry: 1.1.1
+      is-generator-function: 1.1.0
+      is-regex: 1.2.1
+      is-weakref: 1.1.1
+      isarray: 2.0.5
+      which-boxed-primitive: 1.1.1
+      which-collection: 1.0.2
+      which-typed-array: 1.1.19
+
+  which-collection@1.0.2:
+    dependencies:
+      is-map: 2.0.3
+      is-set: 2.0.3
+      is-weakmap: 2.0.2
+      is-weakset: 2.0.4
+
+  which-typed-array@1.1.19:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  word-wrap@1.2.5: {}
 
   wrap-ansi@7.0.0:
     dependencies:
@@ -4406,6 +6871,8 @@ snapshots:
   yallist@4.0.0: {}
 
   yaml@2.7.1: {}
+
+  yocto-queue@0.1.0: {}
 
   yoga-wasm-web@0.3.3: {}
 


### PR DESCRIPTION
Part of issue [#18](https://github.com/globalise-huygens/necessary-reunions/issues/18)
Part of issue [#32](https://github.com/globalise-huygens/necessary-reunions/issues/32)
This PR focuses on handeling IIIF manifest loading better, and introduces some better loading indicators as well as fixes some overlay hierarchy issues.

- [x] Adjust v2 and v3 IIIF Presentation/Image loading
- [x] Add info that this viewer is NOT video and audio IIIF loading compatibility
- [x] Add url manifest loading examples
- [x] Add manifest loading testing
- [x] Change button name
- [x] Add tile loading indicator
- [x] Add better overlay handeling with the leaflet container

Button change:
![Screenshot 2025-07-01 at 11 20 14](https://github.com/user-attachments/assets/156b7eff-c782-4e8e-94d7-027e9f7fdc65)

Current Manifest overlay window view:
![Screenshot 2025-07-01 at 14 38 45](https://github.com/user-attachments/assets/b9fc3a10-bcdf-43bc-9880-304112de46c3)

Tile loading indicator:
<img width="537" alt="Screenshot 2025-07-01 at 11 22 29" src="https://github.com/user-attachments/assets/6ccec3a1-8975-42be-83cf-9a0f890fd386" />

