### PR TITLE
Add icon and coloring for human changed annotations

### DIFF
--- a/components/AnnotationList.tsx
+++ b/components/AnnotationList.tsx
@@ -543,7 +543,17 @@ export function AnnotationList({
                   <div className="flex-1">
                     {isTextAnnotation(annotation) ? (
                       <div className="flex items-center gap-3">
-                        <Type className="h-4 w-4 text-primary flex-shrink-0" />
+                        <div className="flex items-center gap-1 flex-shrink-0">
+                          <Type className="h-4 w-4 text-primary" />
+                          {annotation.creator && (
+                            <div
+                              title="Modified by human"
+                              className="flex items-center"
+                            >
+                              <User className="h-3 w-3 text-muted-foreground" />
+                            </div>
+                          )}
+                        </div>
                         {(() => {
                           const loghiBody = getLoghiBody(annotation);
                           const fallbackBody =
@@ -580,7 +590,17 @@ export function AnnotationList({
                     ) : annotation.motivation === 'iconography' ||
                       annotation.motivation === 'iconograpy' ? (
                       <div className="flex items-start gap-3">
-                        <Image className="h-4 w-4 text-secondary flex-shrink-0 mt-1" />
+                        <div className="flex items-center gap-1 flex-shrink-0 mt-1">
+                          <Image className="h-4 w-4 text-secondary" />
+                          {annotation.creator && (
+                            <div
+                              title="Modified by human"
+                              className="flex items-center"
+                            >
+                              <User className="h-3 w-3 text-muted-foreground" />
+                            </div>
+                          )}
+                        </div>
                         <div className="flex-1">
                           <span className="text-sm text-muted-foreground">
                             Iconography annotation

--- a/components/ImageViewer.tsx
+++ b/components/ImageViewer.tsx
@@ -186,6 +186,7 @@ export function ImageViewer({
 
       const div = document.createElement('div');
       div.dataset.annotationId = anno.id;
+      div.dataset.humanModified = anno.creator ? 'true' : 'false';
       Object.assign(div.style, {
         position: 'absolute',
         pointerEvents: 'auto',
@@ -372,12 +373,18 @@ export function ImageViewer({
             addOverlays(viewer);
             overlaysRef.current.forEach((d) => {
               const isSel = d.dataset.annotationId === selectedAnnotationId;
-              d.style.backgroundColor = isSel
-                ? 'rgba(255,0,0,0.3)'
-                : 'rgba(0,100,255,0.2)';
-              d.style.border = isSel
-                ? '2px solid rgba(255,0,0,0.8)'
-                : '1px solid rgba(0,100,255,0.6)';
+              const isHumanModified = d.dataset.humanModified === 'true';
+
+              if (isSel) {
+                d.style.backgroundColor = 'rgba(255,0,0,0.3)';
+                d.style.border = '2px solid rgba(255,0,0,0.8)';
+              } else if (isHumanModified) {
+                d.style.backgroundColor = 'rgba(174,190,190,0.25)';
+                d.style.border = '1px solid rgba(174,190,190,0.8)';
+              } else {
+                d.style.backgroundColor = 'rgba(0,100,255,0.2)';
+                d.style.border = '1px solid rgba(0,100,255,0.6)';
+              }
             });
             zoomToSelected();
           }
@@ -444,12 +451,18 @@ export function ImageViewer({
 
     overlaysRef.current.forEach((d) => {
       const isSel = d.dataset.annotationId === selectedAnnotationId;
-      d.style.backgroundColor = isSel
-        ? 'rgba(255,0,0,0.3)'
-        : 'rgba(0,100,255,0.2)';
-      d.style.border = isSel
-        ? '2px solid rgba(255,0,0,0.8)'
-        : '1px solid rgba(0,100,255,0.6)';
+      const isHumanModified = d.dataset.humanModified === 'true';
+
+      if (isSel) {
+        d.style.backgroundColor = 'rgba(255,0,0,0.3)';
+        d.style.border = '2px solid rgba(255,0,0,0.8)';
+      } else if (isHumanModified) {
+        d.style.backgroundColor = 'rgba(174,190,190,0.25)';
+        d.style.border = '1px solid rgba(174,190,190,0.8)';
+      } else {
+        d.style.backgroundColor = 'rgba(0,100,255,0.2)';
+        d.style.border = '1px solid rgba(0,100,255,0.6)';
+      }
     });
     zoomToSelected();
   }, [selectedAnnotationId]);
@@ -461,12 +474,18 @@ export function ImageViewer({
       addOverlays(viewerRef.current);
       overlaysRef.current.forEach((d) => {
         const isSel = d.dataset.annotationId === selectedAnnotationId;
-        d.style.backgroundColor = isSel
-          ? 'rgba(255,0,0,0.3)'
-          : 'rgba(0,100,255,0.2)';
-        d.style.border = isSel
-          ? '2px solid rgba(255,0,0,0.8)'
-          : '1px solid rgba(0,100,255,0.6)';
+        const isHumanModified = d.dataset.humanModified === 'true';
+
+        if (isSel) {
+          d.style.backgroundColor = 'rgba(255,0,0,0.3)';
+          d.style.border = '2px solid rgba(255,0,0,0.8)';
+        } else if (isHumanModified) {
+          d.style.backgroundColor = 'rgba(174,190,190,0.25)';
+          d.style.border = '1px solid rgba(174,190,190,0.8)';
+        } else {
+          d.style.backgroundColor = 'rgba(0,100,255,0.2)';
+          d.style.border = '1px solid rgba(0,100,255,0.6)';
+        }
       });
     } else {
       viewerRef.current.clearOverlays();


### PR DESCRIPTION
This PR introduces the tracking of human created and/or changed annotations.

- [x] Add icon to person changed annotation
- [x] Change coloring of the svg annotation when person changed

Screenshot showing the icons when an annotation was changed/created by a person:
![Screenshot 2025-07-08 at 10 07 56](https://github.com/user-attachments/assets/b65e812c-225f-46d5-ac20-286234e1feae)

Screenshot showing the coloring of the svg annotations showing if it was human changed/created:
![Screenshot 2025-07-08 at 10 08 16](https://github.com/user-attachments/assets/e8a1136c-4ff0-4687-b2ee-77bc5eb72bcd)
