### PR TITLE
Adjust the gavoc uri structure and 

### DIFF
--- a/lib/gavoc/data-processing.ts
+++ b/lib/gavoc/data-processing.ts
@@ -83,6 +83,7 @@ export function generateSlug(name: string): string {
 /**
  * Generate a unique URI for a location
  * Format: https://necessaryreunions.org/gavoc/{id}/{slug}
+ * If no meaningful name exists, includes coordinates for uniqueness
  */
 export function generateLocationUri(location: Partial<GavocLocation>): string {
   const baseUrl = 'https://necessaryreunions.org/gavoc';
@@ -93,7 +94,14 @@ export function generateLocationUri(location: Partial<GavocLocation>): string {
       ? location.presentName
       : location.originalNameOnMap || '';
 
-  const slug = generateSlug(primaryName);
+  let slug = generateSlug(primaryName);
+
+  // If no meaningful slug, use coordinates for uniqueness if available
+  if (!slug && location.latitude && location.longitude) {
+    const lat = Math.round(location.latitude * 100) / 100;
+    const lon = Math.round(location.longitude * 100) / 100;
+    slug = `${lat}-${lon}`.replace(/\./g, '_').replace(/-/g, '_');
+  }
 
   if (slug) {
     return `${baseUrl}/${id}/${slug}`;
@@ -104,6 +112,7 @@ export function generateLocationUri(location: Partial<GavocLocation>): string {
 
 /**
  * Generate a URL path for a location (without domain)
+ * Includes coordinates for uniqueness when no meaningful name exists
  */
 export function generateLocationPath(location: Partial<GavocLocation>): string {
   const id = location.id?.replace('gavoc-', '') || location.indexPage || '';
@@ -113,7 +122,14 @@ export function generateLocationPath(location: Partial<GavocLocation>): string {
       ? location.presentName
       : location.originalNameOnMap || '';
 
-  const slug = generateSlug(primaryName);
+  let slug = generateSlug(primaryName);
+
+  // If no meaningful slug, use coordinates for uniqueness if available
+  if (!slug && location.latitude && location.longitude) {
+    const lat = Math.round(location.latitude * 100) / 100;
+    const lon = Math.round(location.longitude * 100) / 100;
+    slug = `${lat}-${lon}`.replace(/\./g, '_').replace(/-/g, '_');
+  }
 
   if (slug) {
     return `/gavoc/${id}/${slug}`;
@@ -207,10 +223,12 @@ export function processGavocData(rawData: any[]): GavocData {
   const thesaurus = buildThesaurus(locations);
 
   locations.forEach((location) => {
+    // Determine the preferred term for this location
     const preferredTerm =
       location.presentName !== '-'
         ? location.presentName
         : location.originalNameOnMap;
+
     if (preferredTerm && preferredTerm !== '-') {
       const coordinates =
         location.latitude && location.longitude
@@ -220,6 +238,7 @@ export function processGavocData(rawData: any[]): GavocData {
             }
           : undefined;
 
+      // Generate concept key to find corresponding thesaurus entry
       const conceptKey = generateConceptKey(
         preferredTerm,
         location.category,
@@ -227,18 +246,22 @@ export function processGavocData(rawData: any[]): GavocData {
       );
       location.thesaurusId = generateThesaurusId(conceptKey);
 
+      // Try to find the thesaurus entry for this location
       const thesaurusEntry = thesaurus.entries.find(
         (entry: GavocThesaurusEntry) => entry.id === location.thesaurusId,
       );
 
       if (thesaurusEntry) {
+        // Use thesaurus URI - this links locations with same concept
         location.uri = thesaurusEntry.uri;
         location.urlPath = thesaurusEntry.urlPath;
       } else {
+        // Fallback to individual location URI
         location.uri = generateLocationUri(location);
         location.urlPath = generateLocationPath(location);
       }
     } else {
+      // No meaningful name, use individual location URI with ID only
       location.uri = generateLocationUri(location);
       location.urlPath = generateLocationPath(location);
     }

--- a/lib/gavoc/url-utils.ts
+++ b/lib/gavoc/url-utils.ts
@@ -1,5 +1,84 @@
 import { parseLocationPath } from './data-processing';
+import { GavocThesaurusEntry } from './thesaurus';
 import { GavocLocation } from './types';
+
+/**
+ * Parse a concept URL path to extract slug and coordinates
+ */
+export function parseConceptPath(
+  path: string,
+): {
+  slug: string;
+  coordinates?: { latitude: number; longitude: number };
+} | null {
+  const conceptMatch = path.match(
+    /^\/gavoc\/c\/([^\/]+)(?:\/(-?\d+(?:\.\d+)?)\/(-?\d+(?:\.\d+)?))?/,
+  );
+  if (!conceptMatch) return null;
+
+  const [, slug, latStr, lonStr] = conceptMatch;
+
+  if (latStr && lonStr) {
+    const latitude = parseFloat(latStr);
+    const longitude = parseFloat(lonStr);
+    if (!isNaN(latitude) && !isNaN(longitude)) {
+      return { slug, coordinates: { latitude, longitude } };
+    }
+  }
+
+  return { slug };
+}
+
+/**
+ * Find a concept by URL path
+ */
+export function findConceptByPath(
+  concepts: GavocThesaurusEntry[],
+  path: string,
+): GavocThesaurusEntry | null {
+  const parsed = parseConceptPath(path);
+  if (!parsed) return null;
+
+  const exactMatch = concepts.find((concept) => concept.urlPath === path);
+  if (exactMatch) return exactMatch;
+
+  const slugMatches = concepts.filter((concept) => {
+    const conceptSlug = concept.urlPath.split('/').pop()?.split('/')[0];
+    return conceptSlug === parsed.slug;
+  });
+
+  if (slugMatches.length === 1) {
+    return slugMatches[0];
+  }
+
+  if (slugMatches.length > 1 && parsed.coordinates) {
+    let closest = slugMatches[0];
+    let minDistance = Infinity;
+
+    for (const concept of slugMatches) {
+      if (concept.coordinates) {
+        const distance = Math.sqrt(
+          Math.pow(
+            concept.coordinates.latitude - parsed.coordinates.latitude,
+            2,
+          ) +
+            Math.pow(
+              concept.coordinates.longitude - parsed.coordinates.longitude,
+              2,
+            ),
+        );
+        if (distance < minDistance) {
+          minDistance = distance;
+          closest = concept;
+        }
+      }
+    }
+
+    return closest;
+  }
+
+  return slugMatches[0] || null;
+}
 
 /**
  * Find a location by ID


### PR DESCRIPTION
This PR focuses on fixing some issues with the GAVOC tool.

- [x] Adjusting the URI structure: incoporating the coordinates to make sure if a duplicate present name is present, and they are at two different locations, each of these places gets their own entry (in the thesaurus structure and for the uri)
- [ ] Fixes the handling of selecting a point in the table or thesaurus and shoing it on the map
- [ ] Fixes the zoom in handling of the map points
- [ ] Fixes the pop-up window duplicates on the map (also the line break of the uri)
- [ ] Fixes the point movement when selected on map