### PR TITLE
Adjust for custom domain for dev mode

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,12 @@ module.exports = {
   eslint: { ignoreDuringBuilds: true },
   typescript: { ignoreBuildErrors: true },
   images: { unoptimized: true },
+  allowedDevOrigins: [
+    'viewer.localhost',
+    'gavoc.localhost',
+    'gazetteer.localhost',
+    '*.localhost',
+  ],
   experimental: {
     webpackBuildWorker: true,
     parallelServerBuildTraces: true,


### PR DESCRIPTION
PR closes #66

Following the pattern mentioned here: [Nextjs Documentation: allowed dev origins](https://nextjs.org/docs/app/api-reference/config/next-config-js/allowedDevOrigins) the next.config.js file was adjusted to fit in the custom urls used in this project for the development mode.

```
module.exports = {
  allowedDevOrigins: ['local-origin.dev', '*.local-origin.dev'],
}
```