### PR TITLE
Add iconography classification structure

### DIFF
--- a/components/shared/Select.tsx
+++ b/components/shared/Select.tsx
@@ -74,7 +74,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'relative z-50 max-h-96 min-w-[12rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         position === 'popper' &&
           'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
         className,
@@ -117,12 +117,12 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex w-full cursor-default select-none items-start rounded-sm py-2 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-white data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className,
     )}
     {...props}
   >
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+    <span className="absolute left-2 top-2 flex h-3.5 w-3.5 items-center justify-center">
       <SelectPrimitive.ItemIndicator>
         <Check className="h-4 w-4" />
       </SelectPrimitive.ItemIndicator>

--- a/components/viewer/ClassificationSelector.tsx
+++ b/components/viewer/ClassificationSelector.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/shared/Select';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/shared/Tooltip';
+import type { Annotation } from '@/lib/types';
+import { Info } from 'lucide-react';
+import React, { useEffect, useState } from 'react';
+
+interface ClassificationSelectorProps {
+  annotation: Annotation;
+  currentClassificationId?: string;
+  currentClassificationLabel?: string;
+  canEdit: boolean;
+  onClassificationUpdate: (
+    annotation: Annotation,
+    classificationId: string | null,
+  ) => Promise<void>;
+}
+
+interface ThesaurusConcept {
+  '@id': string;
+  '@type': string;
+  prefLabel: {
+    '@language': string;
+    '@value': string;
+  };
+  altLabel?: Array<{
+    '@language': string;
+    '@value': string;
+  }>;
+  definition?: {
+    '@language': string;
+    '@value': string;
+  };
+}
+
+interface IconographyThesaurus {
+  '@context': any;
+  '@graph': ThesaurusConcept[];
+}
+
+export const ClassificationSelector = React.memo(
+  function ClassificationSelector({
+    annotation,
+    currentClassificationId,
+    currentClassificationLabel,
+    canEdit,
+    onClassificationUpdate,
+  }: ClassificationSelectorProps) {
+    const [thesaurus, setThesaurus] = useState<IconographyThesaurus | null>(
+      null,
+    );
+    const [isLoading, setIsLoading] = useState(false);
+    const [isSaving, setIsSaving] = useState(false);
+
+    useEffect(() => {
+      const loadThesaurus = async () => {
+        setIsLoading(true);
+        try {
+          const response = await fetch('/iconography-thesaurus.json');
+          if (!response.ok) {
+            throw new Error('Failed to load iconography thesaurus');
+          }
+          const data = await response.json();
+          setThesaurus(data);
+        } catch (error) {
+          console.error('Error loading iconography thesaurus:', error);
+        } finally {
+          setIsLoading(false);
+        }
+      };
+
+      loadThesaurus();
+    }, []);
+
+    const handleSelectionChange = async (value: string) => {
+      if (!canEdit || isSaving) return;
+
+      setIsSaving(true);
+      try {
+        const classificationId = value === 'none' ? null : value;
+        await onClassificationUpdate(annotation, classificationId);
+      } catch (error) {
+        console.error('Error updating classification:', error);
+      } finally {
+        setIsSaving(false);
+      }
+    };
+
+    // Helper function to get English translation
+    const getEnglishLabel = (concept: ThesaurusConcept): string => {
+      const englishAltLabel = concept.altLabel?.find(
+        (alt) => alt['@language'] === 'en',
+      );
+      return englishAltLabel?.['@value'] || concept.prefLabel['@value'];
+    };
+
+    // Helper function to format display label (Dutch + English) - more compact
+    const formatDisplayLabel = (concept: ThesaurusConcept): string => {
+      const dutch = concept.prefLabel['@value'];
+      const english = getEnglishLabel(concept);
+
+      if (dutch === english || concept.prefLabel['@language'] === 'en') {
+        return dutch; // Only show one if they're the same or if primary is already English
+      }
+
+      // Make it more compact by using shorter format
+      return `${dutch} (${
+        english.length > 15 ? english.substring(0, 12) + '...' : english
+      })`;
+    };
+
+    // Helper function to get definition - more concise
+    const getDefinition = (concept: ThesaurusConcept): string => {
+      const definition =
+        concept.definition?.['@value'] || 'No definition available';
+      // Truncate very long definitions
+      return definition.length > 80
+        ? definition.substring(0, 77) + '...'
+        : definition;
+    };
+
+    if (isLoading) {
+      return (
+        <div className="text-xs text-muted-foreground">
+          Loading classifications...
+        </div>
+      );
+    }
+
+    if (!thesaurus) {
+      return (
+        <div className="text-xs text-destructive">
+          Failed to load classifications
+        </div>
+      );
+    }
+
+    // Extract classification ID from full URL
+    const shortClassificationId = currentClassificationId
+      ? currentClassificationId.split('/').pop()
+      : '';
+
+    const selectOptions = [
+      {
+        value: 'none',
+        label: 'No classification',
+        definition: 'Remove classification from this annotation',
+      },
+      ...thesaurus['@graph'].map((concept) => ({
+        value: concept['@id'],
+        label: formatDisplayLabel(concept),
+        definition: getDefinition(concept),
+        concept: concept,
+      })),
+    ];
+
+    const currentValue = shortClassificationId || 'none';
+    const currentConcept = thesaurus['@graph'].find(
+      (c) => c['@id'] === shortClassificationId,
+    );
+
+    return (
+      <TooltipProvider>
+        <div className="space-y-2 max-w-full">
+          <Select
+            value={currentValue}
+            onValueChange={handleSelectionChange}
+            disabled={!canEdit || isSaving}
+          >
+            <SelectTrigger className="w-full text-xs max-w-[280px] h-12">
+              <SelectValue
+                placeholder={
+                  isSaving ? 'Saving...' : 'Select a classification...'
+                }
+              />
+            </SelectTrigger>
+            <SelectContent className="w-[var(--radix-select-trigger-width)] max-w-[280px]">
+              {selectOptions.map((option) => (
+                <SelectItem
+                  key={option.value}
+                  value={option.value}
+                  className="group min-h-[2.5rem] py-1.5"
+                >
+                  <div className="flex flex-col items-start w-full min-w-0 overflow-hidden">
+                    <span className="font-medium text-xs truncate w-full">
+                      {option.label}
+                    </span>
+                    <span
+                      className="text-xs text-muted-foreground leading-tight w-full overflow-hidden"
+                      style={{
+                        display: '-webkit-box',
+                        WebkitLineClamp: 2,
+                        WebkitBoxOrient: 'vertical',
+                        textOverflow: 'ellipsis',
+                      }}
+                    >
+                      {option.definition}
+                    </span>
+                  </div>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {/* {currentClassificationLabel && currentClassificationId && (
+            <div className="text-xs text-muted-foreground break-words">
+              Current:{' '}
+              <span className="font-medium">
+                {currentConcept
+                  ? formatDisplayLabel(currentConcept)
+                  : currentClassificationLabel}
+              </span>
+            </div>
+          )} */}
+        </div>
+      </TooltipProvider>
+    );
+  },
+);

--- a/public/iconography-thesaurus.json
+++ b/public/iconography-thesaurus.json
@@ -1,0 +1,240 @@
+{
+  "@context": {
+    "@vocab": "https://data.globalise.huygens.knaw.nl/thesaurus/icons/",
+    "label": "http://www.w3.org/2000/01/rdf-schema#label",
+    "prefLabel": "http://www.w3.org/2004/02/skos/core#prefLabel",
+    "altLabel": "http://www.w3.org/2004/02/skos/core#altLabel",
+    "definition": "http://www.w3.org/2004/02/skos/core#definition",
+    "Concept": "http://www.w3.org/2004/02/skos/core#Concept"
+  },
+  "@graph": [
+    {
+      "@id": "pagger",
+      "@type": "Concept",
+      "prefLabel": {
+        "@language": "nl",
+        "@value": "Pagger"
+      },
+      "altLabel": [
+        {
+          "@language": "en",
+          "@value": "Stockade"
+        },
+        {
+          "@language": "en",
+          "@value": "Palisade"
+        }
+      ],
+      "definition": {
+        "@language": "en",
+        "@value": "A defensive structure made of wooden stakes or posts"
+      }
+    },
+    {
+      "@id": "pagood",
+      "@type": "Concept",
+      "prefLabel": {
+        "@language": "nl",
+        "@value": "Pagood"
+      },
+      "altLabel": [
+        {
+          "@language": "en",
+          "@value": "Temple"
+        },
+        {
+          "@language": "en",
+          "@value": "Pagoda"
+        }
+      ],
+      "definition": {
+        "@language": "en",
+        "@value": "A religious building, typically a Buddhist or Hindu temple"
+      }
+    },
+    {
+      "@id": "bazaar",
+      "@type": "Concept",
+      "prefLabel": {
+        "@language": "en",
+        "@value": "Bazaar"
+      },
+      "altLabel": [
+        {
+          "@language": "nl",
+          "@value": "Markt"
+        },
+        {
+          "@language": "en",
+          "@value": "Market"
+        }
+      ],
+      "definition": {
+        "@language": "en",
+        "@value": "A marketplace or commercial area"
+      }
+    },
+    {
+      "@id": "moorsche_temple",
+      "@type": "Concept",
+      "prefLabel": {
+        "@language": "nl",
+        "@value": "Moorsche Temple"
+      },
+      "altLabel": [
+        {
+          "@language": "en",
+          "@value": "Mosque"
+        },
+        {
+          "@language": "en",
+          "@value": "Islamic Temple"
+        }
+      ],
+      "definition": {
+        "@language": "en",
+        "@value": "A place of worship for followers of Islam"
+      }
+    },
+    {
+      "@id": "fortresse",
+      "@type": "Concept",
+      "prefLabel": {
+        "@language": "nl",
+        "@value": "Fortresse"
+      },
+      "altLabel": [
+        {
+          "@language": "en",
+          "@value": "Fortress"
+        },
+        {
+          "@language": "en",
+          "@value": "Fort"
+        }
+      ],
+      "definition": {
+        "@language": "en",
+        "@value": "A fortified defensive structure or military stronghold"
+      }
+    },
+    {
+      "@id": "zoutpannen",
+      "@type": "Concept",
+      "prefLabel": {
+        "@language": "nl",
+        "@value": "Zoutpannen"
+      },
+      "altLabel": [
+        {
+          "@language": "en",
+          "@value": "Saltpans"
+        },
+        {
+          "@language": "en",
+          "@value": "Salt works"
+        }
+      ],
+      "definition": {
+        "@language": "en",
+        "@value": "Areas used for salt production through evaporation"
+      }
+    },
+    {
+      "@id": "kerk",
+      "@type": "Concept",
+      "prefLabel": {
+        "@language": "nl",
+        "@value": "Kerk"
+      },
+      "altLabel": [
+        {
+          "@language": "en",
+          "@value": "Church"
+        }
+      ],
+      "definition": {
+        "@language": "en",
+        "@value": "A Christian place of worship"
+      }
+    },
+    {
+      "@id": "settlement",
+      "@type": "Concept",
+      "prefLabel": {
+        "@language": "en",
+        "@value": "Settlement"
+      },
+      "altLabel": [
+        {
+          "@language": "nl",
+          "@value": "Nederzetting"
+        },
+        {
+          "@language": "en",
+          "@value": "Village"
+        }
+      ],
+      "definition": {
+        "@language": "en",
+        "@value": "A community or residential area, often inferred from context rather than explicitly marked"
+      }
+    },
+    {
+      "@id": "paleys_huis",
+      "@type": "Concept",
+      "prefLabel": {
+        "@language": "nl",
+        "@value": "Paleys/Huis"
+      },
+      "altLabel": [
+        {
+          "@language": "en",
+          "@value": "Palace"
+        },
+        {
+          "@language": "en",
+          "@value": "House"
+        },
+        {
+          "@language": "en",
+          "@value": "Residence"
+        }
+      ],
+      "definition": {
+        "@language": "en",
+        "@value": "A palace, large house, or important residential building"
+      }
+    },
+    {
+      "@id": "company_possession",
+      "@type": "Concept",
+      "prefLabel": {
+        "@language": "en",
+        "@value": "Company Possession"
+      },
+      "altLabel": [
+        {
+          "@language": "nl",
+          "@value": "Residentie"
+        },
+        {
+          "@language": "en",
+          "@value": "Residency"
+        },
+        {
+          "@language": "en",
+          "@value": "Watchpost"
+        },
+        {
+          "@language": "en",
+          "@value": "Trading post"
+        }
+      ],
+      "definition": {
+        "@language": "en",
+        "@value": "Buildings or areas controlled by the Dutch East India Company, including residencies and watchposts"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds the classification structure to the iconography annotation.

- [x] Figure out a design
- [x] Add the proper iconography classification saving structure

Classification UI in the iconography annotation:
<img width="303" height="397" alt="Screenshot 2025-10-01 at 12 45 11" src="https://github.com/user-attachments/assets/1b878853-176c-4c8d-bec9-01f43b05c3b4" />

Drop down menu:
<img width="262" height="451" alt="Screenshot 2025-10-01 at 12 45 32" src="https://github.com/user-attachments/assets/e8c29247-a27f-4d5d-b955-ce519dfe98f8" />